### PR TITLE
improve: MirrorLive code quality, tests, and inline CSS removal

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2106,6 +2106,39 @@ details[open] summary {
   padding: 20px;
 }
 
+/* ---- MIRROR LIVE ---- */
+.mirror-window {
+  width: 100%;
+  height: calc(100vh - 40px);
+  max-width: none;
+}
+
+.mirror-content {
+  height: calc(100% - 60px);
+  overflow-y: auto;
+  background: #1a1a2e;
+}
+
+.mirror-code {
+  tab-size: 2;
+}
+
+.mirror-char {
+  display: inline-block;
+}
+
+@keyframes mirror-spin-5  { from { transform: rotate(0deg); } to { transform: rotate(-360deg); } }
+@keyframes mirror-spin-6  { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+@keyframes mirror-spin-7  { from { transform: rotate(0deg); } to { transform: rotate(-360deg); } }
+@keyframes mirror-spin-8  { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+@keyframes mirror-spin-9  { from { transform: rotate(0deg); } to { transform: rotate(-360deg); } }
+@keyframes mirror-spin-10 { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+@keyframes mirror-spin-11 { from { transform: rotate(0deg); } to { transform: rotate(-360deg); } }
+@keyframes mirror-spin-12 { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+@keyframes mirror-spin-13 { from { transform: rotate(0deg); } to { transform: rotate(-360deg); } }
+@keyframes mirror-spin-14 { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+@keyframes mirror-spin-15 { from { transform: rotate(0deg); } to { transform: rotate(-360deg); } }
+
 /* Utility: inner content padding */
 .os-content-padded {
   padding: 16px;

--- a/lib/blog/code_decompiler.ex
+++ b/lib/blog/code_decompiler.ex
@@ -1,12 +1,26 @@
-defmodule CodeDecompiler do
+defmodule Blog.CodeDecompiler do
+  @moduledoc """
+  Decompiles BEAM modules back to Elixir source code.
+
+  Uses BEAM abstract code chunks to reconstruct quoted Elixir expressions,
+  then formats them as source strings. Used by MirrorLive to display
+  its own source code.
+  """
+
+  @doc """
+  Decompiles a loaded BEAM module to an Elixir source string.
+
+  Returns the source code as a string on success, or `{:error, reason}` on failure.
+  """
+  @spec decompile_to_string(module()) :: String.t() | {:error, term()}
   def decompile_to_string(module) when is_atom(module) do
     path = :code.which(module)
 
     case :beam_lib.chunks(path, [:abstract_code]) do
       {:ok, {_, [{:abstract_code, {:raw_abstract_v1, abstract_code}}]}} ->
-        # Convert the abstract format to quoted expressions
         quoted =
-          Enum.map(abstract_code, &abstract_code_to_quoted/1)
+          abstract_code
+          |> Enum.map(&abstract_code_to_quoted/1)
           |> Enum.reject(&is_nil/1)
           |> wrap_in_module(module)
 
@@ -49,9 +63,22 @@ defmodule CodeDecompiler do
   # Skip compile attributes
   defp abstract_code_to_quoted({:attribute, _, :compile, _}), do: nil
 
+  defp abstract_code_to_quoted({:attribute, _, :spec, _}), do: nil
+  defp abstract_code_to_quoted({:attribute, _, :type, _}), do: nil
+  defp abstract_code_to_quoted({:attribute, _, :opaque, _}), do: nil
+  defp abstract_code_to_quoted({:attribute, _, :callback, _}), do: nil
+  defp abstract_code_to_quoted({:attribute, _, :optional_callbacks, _}), do: nil
+  defp abstract_code_to_quoted({:attribute, _, :behaviour, _}), do: nil
+  defp abstract_code_to_quoted({:attribute, _, :dialyzer, _}), do: nil
+  defp abstract_code_to_quoted({:attribute, _, :file, _}), do: nil
+
   defp abstract_code_to_quoted({:attribute, line, name, value}) do
-    quote line: normalize_line(line) do
-      Module.put_attribute(__MODULE__, unquote(name), unquote(convert_attribute_value(value)))
+    try do
+      quote line: normalize_line(line) do
+        Module.put_attribute(__MODULE__, unquote(name), unquote(convert_attribute_value(value)))
+      end
+    rescue
+      _ -> nil
     end
   end
 
@@ -66,15 +93,22 @@ defmodule CodeDecompiler do
         nil
 
       name when is_atom(name) ->
-        function_clauses = Enum.map(clauses, &clause_to_quoted/1)
+        try do
+          function_clauses = Enum.map(clauses, &clause_to_quoted/1)
 
-        quote line: normalize_line(line) do
-          def unquote(name)(unquote_splicing(make_vars(arity))) do
-            unquote(function_clauses)
+          quote line: normalize_line(line) do
+            def unquote(name)(unquote_splicing(make_vars(arity))) do
+              unquote(function_clauses)
+            end
           end
+        rescue
+          _ -> nil
         end
     end
   end
+
+  # Catch-all for unrecognized abstract code forms
+  defp abstract_code_to_quoted(_), do: nil
 
   # Function clauses
   defp clause_to_quoted({:clause, line, params, guards, body}) do

--- a/lib/blog/mirror/source_processor.ex
+++ b/lib/blog/mirror/source_processor.ex
@@ -1,0 +1,78 @@
+defmodule Blog.Mirror.SourceProcessor do
+  @moduledoc """
+  Pure functions for processing source code into animated character data.
+
+  Converts source code strings into structured data where each character
+  has animation properties (duration, delay, direction) for the spinning
+  code display in MirrorLive.
+  """
+
+  @type char_data :: %{
+          char: String.t(),
+          duration: pos_integer(),
+          delay: non_neg_integer(),
+          direction: -1 | 1
+        }
+
+  @doc """
+  Processes source code into a list of lines, each containing character data.
+
+  Each character gets random animation properties for the spinning display.
+  """
+  @spec process(String.t()) :: [[char_data()]]
+  def process(source) when is_binary(source) do
+    source
+    |> String.split("\n")
+    |> Enum.map(&process_line/1)
+  end
+
+  def process({:error, _reason}), do: process(fallback_source())
+  def process(_other), do: process(fallback_source())
+
+  @doc """
+  Processes a single line of source code into character data.
+  """
+  @spec process_line(String.t()) :: [char_data()]
+  def process_line(line) when is_binary(line) do
+    line
+    |> String.graphemes()
+    |> Enum.map(&build_char_data/1)
+  end
+
+  @doc """
+  Builds animation data for a single character.
+  """
+  @spec build_char_data(String.t()) :: char_data()
+  def build_char_data(char) do
+    %{
+      char: char,
+      duration: :rand.uniform(10) + 5,
+      delay: :rand.uniform(5000),
+      direction: if(:rand.uniform() > 0.5, do: 1, else: -1)
+    }
+  end
+
+  @doc """
+  Returns fallback source code when the actual source cannot be loaded.
+  """
+  @spec fallback_source() :: String.t()
+  def fallback_source do
+    """
+    defmodule BlogWeb.MirrorLive do
+      use BlogWeb, :live_view
+
+      # Source code could not be loaded
+      # This is a fallback representation
+
+      def render(assigns) do
+        ~H\"\"\"
+        <div>
+          <h1>Mirror Mirror on the wall</h1>
+          <p>Source code could not be loaded</p>
+        </div>
+        \"\"\"
+      end
+    end
+    """
+  end
+end

--- a/lib/blog_web/live/mirror_live.ex
+++ b/lib/blog_web/live/mirror_live.ex
@@ -1,143 +1,46 @@
 defmodule BlogWeb.MirrorLive do
+  @moduledoc "Self-reflecting code display that shows its own source with spinning character animations."
   use BlogWeb, :live_view
+
   require Logger
+
+  alias Blog.Mirror.SourceProcessor
 
   @source_url "https://raw.githubusercontent.com/notactuallytreyanastasio/blog/main/lib/blog_web/live/mirror_live.ex"
 
+  @impl true
   def mount(_params, _session, socket) do
     if connected?(socket) do
-      # Fetch source code asynchronously when client connects
       Task.async(fn -> fetch_source_code() end)
     end
 
     {:ok,
      assign(socket,
-       source_code: "Loading source code...",
+       lines: nil,
        page_title: "I am looking at myself",
-       meta_attrs: [
-         %{name: "title", content: "Mirror Mirror on the wall"},
-         %{name: "description", content: "A page that shows its own source code"},
-         %{property: "og:title", content: "Mirror Mirror on the wall"},
-         %{property: "og:description", content: "A page that shows its own source code"},
-         %{property: "og:type", content: "website"}
-       ]
+       page_description: "A page that shows its own source code",
+       page_image: nil
      )}
   end
 
+  @impl true
   def handle_info({ref, source_code}, socket) when is_reference(ref) do
-    # Flush the DOWN message
     Process.demonitor(ref, [:flush])
-
-    # Process the source code
-    characters = process_source_code(source_code)
-
+    characters = SourceProcessor.process(source_code)
     {:noreply, assign(socket, lines: characters)}
   end
 
   def handle_info({:DOWN, _, :process, _, reason}, socket) do
     Logger.error("Failed to fetch source code: #{inspect(reason)}")
-
-    # Create a fallback source code
-    fallback = fallback_source_code()
-    characters = process_source_code(fallback)
-
+    characters = SourceProcessor.process(SourceProcessor.fallback_source())
     {:noreply, assign(socket, lines: characters)}
   end
 
-  defp process_source_code(source) do
-    # Handle both string and error tuple cases
-    source_str =
-      case source do
-        {:error, reason} ->
-          Logger.error("Error decompiling source: #{inspect(reason)}")
-          fallback_source_code()
-
-        str when is_binary(str) ->
-          str
-
-        other ->
-          Logger.error("Unexpected source format: #{inspect(other)}")
-          fallback_source_code()
-      end
-
-    # Split into lines first, then characters
-    source_str
-    |> String.split("\n")
-    |> Enum.map(fn line ->
-      line
-      |> String.graphemes()
-      |> Enum.map(fn char ->
-        %{
-          char: char,
-          duration: :rand.uniform(10) + 5,
-          delay: :rand.uniform(5000),
-          direction: if(:rand.uniform() > 0.5, do: 1, else: -1)
-        }
-      end)
-    end)
-  end
-
-  defp fallback_source_code do
-    """
-    defmodule BlogWeb.MirrorLive do
-      use BlogWeb, :live_view
-
-      # Source code could not be loaded
-      # This is a fallback representation
-
-      def render(assigns) do
-        ~H\"\"\"
-        <div>
-          <h1>Mirror Mirror on the wall</h1>
-          <p>Source code could not be loaded</p>
-        </div>
-        \"\"\"
-      end
-    end
-    """
-  end
-
-  defp fetch_source_code do
-    try do
-      # Try to decompile first
-      result = CodeDecompiler.decompile_to_string(__MODULE__)
-
-      # If result is an error tuple, try fetching from GitHub
-      case result do
-        {:error, _} ->
-          fetch_from_github()
-
-        _ ->
-          result
-      end
-    rescue
-      e ->
-        Logger.error("Exception decompiling: #{inspect(e)}")
-        fetch_from_github()
-    end
-  end
-
-  defp fetch_from_github do
-    try do
-      case Req.get(@source_url) do
-        {:ok, %{status: 200, body: body}} ->
-          body
-
-        error ->
-          Logger.error("Failed to fetch from GitHub: #{inspect(error)}")
-          fallback_source_code()
-      end
-    rescue
-      e ->
-        Logger.error("Exception fetching from GitHub: #{inspect(e)}")
-        fallback_source_code()
-    end
-  end
-
+  @impl true
   def render(assigns) do
     ~H"""
     <div class="os-desktop-osx">
-      <div class="os-window os-window-osx" style="width: 100%; height: calc(100vh - 40px); max-width: none;">
+      <div class="os-window os-window-osx mirror-window">
         <div class="os-titlebar">
           <div class="os-titlebar-buttons">
             <a href="/" class="os-btn-close"></a>
@@ -147,13 +50,13 @@ defmodule BlogWeb.MirrorLive do
           <span class="os-titlebar-title">Mirror.app - Self-Reflecting Code</span>
           <div class="os-titlebar-spacer"></div>
         </div>
-        <div class="os-content" style="height: calc(100% - 60px); overflow-y: auto; background: #1a1a2e;">
+        <div class="os-content mirror-content">
           <div class="p-6">
             <h1 class="text-2xl font-bold mb-6 text-white">
               Mirror Mirror on the wall, who's the most meta of them all?
             </h1>
             <div class="bg-gray-800 rounded-lg p-6 shadow-lg">
-              <pre class="text-sm font-mono text-white" style="tab-size: 2;"><code class="language-elixir"><%= if assigns[:lines] do %><%= for line <- @lines do %><%= for char <- line do %><span style={"display: inline-block; animation: spin#{char.duration} #{char.duration}s linear #{char.delay}ms infinite;"}><%= char.char %></span><% end %>
+              <pre class="text-sm font-mono text-white mirror-code"><code class="language-elixir"><%= if @lines do %><%= for line <- @lines do %><%= for char <- line do %><span class="mirror-char" style={"animation: mirror-spin-#{char.duration} #{char.duration}s linear #{char.delay}ms infinite;"}><%= char.char %></span><% end %>
               <% end %><% else %>Loading source code...<% end %></code></pre>
             </div>
           </div>
@@ -164,19 +67,35 @@ defmodule BlogWeb.MirrorLive do
         </div>
       </div>
     </div>
-
-    <style>
-      <%= for duration <- 5..15 do %>
-        @keyframes spin<%= duration %> {
-          from { transform: rotate(0deg); }
-          to { transform: rotate(<%= if rem(duration, 2) == 0, do: "360", else: "-360" %>deg); }
-        }
-      <% end %>
-    </style>
     """
   end
 
-  @doc """
-  Source code available at: #{@source_url}
-  """
+  defp fetch_source_code do
+    case Blog.CodeDecompiler.decompile_to_string(__MODULE__) do
+      {:error, _} -> fetch_from_github()
+      result when is_binary(result) -> result
+    end
+  rescue
+    e ->
+      Logger.error("Exception decompiling: #{inspect(e)}")
+      fetch_from_github()
+  end
+
+  defp fetch_from_github do
+    case Req.get(@source_url) do
+      {:ok, %{status: 200, body: body}} ->
+        body
+
+      error ->
+        Logger.error("Failed to fetch from GitHub: #{inspect(error)}")
+        SourceProcessor.fallback_source()
+    end
+  rescue
+    e ->
+      Logger.error("Exception fetching from GitHub: #{inspect(e)}")
+      SourceProcessor.fallback_source()
+  end
+
+  @doc false
+  def source_url, do: @source_url
 end

--- a/test/blog/code_decompiler_test.exs
+++ b/test/blog/code_decompiler_test.exs
@@ -1,0 +1,36 @@
+defmodule Blog.CodeDecompilerTest do
+  use ExUnit.Case, async: true
+
+  alias Blog.CodeDecompiler
+
+  describe "decompile_to_string/1" do
+    test "decompiles a known project module to a string" do
+      # Blog.Mirror.SourceProcessor is a simple project module
+      result = CodeDecompiler.decompile_to_string(Blog.Mirror.SourceProcessor)
+
+      assert is_binary(result)
+      assert result =~ "SourceProcessor"
+    end
+
+    test "decompiled output contains function definitions" do
+      result = CodeDecompiler.decompile_to_string(Blog.Mirror.SourceProcessor)
+
+      assert is_binary(result)
+      assert result =~ "def"
+    end
+
+    test "returns error for non-loadable module" do
+      # A module atom that doesn't exist - :code.which returns :non_existing
+      result = CodeDecompiler.decompile_to_string(NonExistentModuleThatDoesNotExist)
+
+      assert {:error, _reason} = result
+    end
+
+    test "returns a string, not an error tuple, for valid modules" do
+      result = CodeDecompiler.decompile_to_string(Blog.Mirror.SourceProcessor)
+
+      refute match?({:error, _}, result)
+      assert is_binary(result)
+    end
+  end
+end

--- a/test/blog/mirror/source_processor_test.exs
+++ b/test/blog/mirror/source_processor_test.exs
@@ -1,0 +1,143 @@
+defmodule Blog.Mirror.SourceProcessorTest do
+  use ExUnit.Case, async: true
+
+  alias Blog.Mirror.SourceProcessor
+
+  describe "process/1" do
+    test "splits source into lines of character data" do
+      result = SourceProcessor.process("ab\ncd")
+
+      assert length(result) == 2
+      assert length(Enum.at(result, 0)) == 2
+      assert length(Enum.at(result, 1)) == 2
+    end
+
+    test "each character has required animation keys" do
+      [[char_data | _] | _] = SourceProcessor.process("x")
+
+      assert Map.has_key?(char_data, :char)
+      assert Map.has_key?(char_data, :duration)
+      assert Map.has_key?(char_data, :delay)
+      assert Map.has_key?(char_data, :direction)
+    end
+
+    test "preserves the original characters" do
+      [[a, b] | _] = SourceProcessor.process("hi")
+
+      assert a.char == "h"
+      assert b.char == "i"
+    end
+
+    test "handles empty string" do
+      result = SourceProcessor.process("")
+
+      assert result == [[]]
+    end
+
+    test "handles multiline code" do
+      source = """
+      defmodule Foo do
+        def bar, do: :ok
+      end
+      """
+
+      result = SourceProcessor.process(source)
+
+      # Should have multiple lines
+      assert length(result) > 1
+
+      # First line should start with 'd' for 'defmodule'
+      first_char = result |> Enum.at(0) |> Enum.at(0)
+      assert first_char.char == "d"
+    end
+
+    test "handles error tuple by returning fallback" do
+      result = SourceProcessor.process({:error, :some_reason})
+
+      assert is_list(result)
+      assert length(result) > 0
+    end
+
+    test "handles non-string input by returning fallback" do
+      result = SourceProcessor.process(42)
+
+      assert is_list(result)
+      assert length(result) > 0
+    end
+  end
+
+  describe "process_line/1" do
+    test "converts a line into character data list" do
+      result = SourceProcessor.process_line("abc")
+
+      assert length(result) == 3
+      assert Enum.at(result, 0).char == "a"
+      assert Enum.at(result, 1).char == "b"
+      assert Enum.at(result, 2).char == "c"
+    end
+
+    test "handles empty line" do
+      assert SourceProcessor.process_line("") == []
+    end
+
+    test "handles unicode characters" do
+      result = SourceProcessor.process_line("héllo")
+
+      chars = Enum.map(result, & &1.char)
+      assert chars == ["h", "é", "l", "l", "o"]
+    end
+  end
+
+  describe "build_char_data/1" do
+    test "returns map with correct char" do
+      result = SourceProcessor.build_char_data("x")
+
+      assert result.char == "x"
+    end
+
+    test "duration is between 6 and 15" do
+      for _ <- 1..100 do
+        result = SourceProcessor.build_char_data("a")
+        assert result.duration >= 6 and result.duration <= 15
+      end
+    end
+
+    test "delay is between 1 and 5000" do
+      for _ <- 1..100 do
+        result = SourceProcessor.build_char_data("a")
+        assert result.delay >= 1 and result.delay <= 5000
+      end
+    end
+
+    test "direction is either 1 or -1" do
+      for _ <- 1..100 do
+        result = SourceProcessor.build_char_data("a")
+        assert result.direction in [1, -1]
+      end
+    end
+  end
+
+  describe "fallback_source/0" do
+    test "returns a non-empty string" do
+      result = SourceProcessor.fallback_source()
+
+      assert is_binary(result)
+      assert byte_size(result) > 0
+    end
+
+    test "contains expected module name" do
+      result = SourceProcessor.fallback_source()
+
+      assert result =~ "BlogWeb.MirrorLive"
+    end
+
+    test "is valid enough to be processed" do
+      result =
+        SourceProcessor.fallback_source()
+        |> SourceProcessor.process()
+
+      assert is_list(result)
+      assert length(result) > 1
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **Remove inline CSS** from MirrorLive — moved all `style=` and `<style>` blocks to `app.css` classes (`mirror-window`, `mirror-content`, `mirror-code`, `mirror-char`, `@keyframes mirror-spin-*`)
- **Extract `Blog.Mirror.SourceProcessor`** — pure functions for converting source code to animated character data (functional core)
- **Rename & namespace `CodeDecompiler`** → `Blog.CodeDecompiler` (moved from `lib/code_inspector.ex` to `lib/blog/code_decompiler.ex`)
- **Fix CodeDecompiler resilience** — skip type specs, rescue unquotable attributes/functions instead of crashing
- **Add `@impl true`, `@moduledoc`, `@spec`** to all modules
- **Remove dead code** — unused `source_code` assign, redundant nested try/catch
- **21 new tests**, all passing, zero Credo issues in strict mode

## Test Coverage Added

| Module | Tests | Type |
|--------|-------|------|
| `Blog.Mirror.SourceProcessor` | 17 | Pure functions (process, process_line, build_char_data, fallback_source) |
| `Blog.CodeDecompiler` | 4 | Decompilation of known modules, error handling |

## Architecture

**Before**: MirrorLive had business logic (source processing), inline CSS, and a bare `CodeDecompiler` at project root.

**After**: 
- `Blog.Mirror.SourceProcessor` — pure functional core (testable)
- `Blog.CodeDecompiler` — properly namespaced utility
- `BlogWeb.MirrorLive` — thin imperative shell (fetch + render)
- `app.css` — all mirror styles in CSS classes

## Test plan

- [x] All 21 new tests pass
- [x] Zero compiler warnings in mirror/decompiler modules
- [x] Zero Credo issues in strict mode
- [x] Spinning character animation still works (keyframes in CSS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)