### PR TITLE
Phase 3 (types): content subsystem @specs

### DIFF
--- a/lib/blog/content.ex
+++ b/lib/blog/content.ex
@@ -6,6 +6,16 @@ defmodule Blog.Content do
   @tech_tags ~w(programming tech software coding elixir javascript phoenix blog)
   @posts_dir "priv/static/posts/"
 
+  @typedoc "A post summary parsed from a markdown file (tags as raw strings)."
+  @type post_summary :: %{
+          title: String.t(),
+          tags: [String.t()],
+          content: String.t(),
+          written_on: Date.t(),
+          slug: String.t()
+        }
+
+  @spec list_posts() :: [post_summary()]
   def list_posts do
     File.ls!(@posts_dir)
     |> Enum.map(&parse_post/1)
@@ -46,6 +56,10 @@ defmodule Blog.Content do
     String.split(tags, ",") |> Enum.map(&String.trim/1)
   end
 
+  @spec categorize_posts([Blog.Content.Post.t()]) :: %{
+          tech: [Blog.Content.Post.t()],
+          non_tech: [Blog.Content.Post.t()]
+        }
   def categorize_posts(posts) do
     data =
       %{tech: tech_list, non_tech: non_tech_list} =

--- a/lib/blog/content/image_generator.ex
+++ b/lib/blog/content/image_generator.ex
@@ -4,6 +4,7 @@ defmodule Blog.Content.ImageGenerator do
   @cache_dir "priv/static/images/posts"
   @public_path "/images/posts"
 
+  @spec ensure_post_image(String.t()) :: String.t() | nil
   def ensure_post_image(slug) do
     filename = "#{slug}.png"
     path = Path.join(@cache_dir, filename)

--- a/lib/blog/content/post.ex
+++ b/lib/blog/content/post.ex
@@ -1,4 +1,14 @@
 defmodule Blog.Content.Post do
+  @type t :: %__MODULE__{
+          body: String.t() | nil,
+          title: String.t() | nil,
+          written_on: NaiveDateTime.t() | nil,
+          tags: [Blog.Content.Tag.t()] | nil,
+          slug: String.t() | nil,
+          author_name: String.t() | nil,
+          is_guest_post: boolean() | nil
+        }
+
   defstruct [:body, :title, :written_on, :tags, :slug, :author_name, :is_guest_post]
 
   # Allowlist of posts to display (excludes cached/deleted posts from old deploys)
@@ -18,6 +28,7 @@ defmodule Blog.Content.Post do
     vibe-coding-rescue-missions
   )
 
+  @spec all() :: [t()]
   def all do
     file_posts =
       ((:code.priv_dir(:blog) |> to_string) <> "/static/posts/*.md")
@@ -54,7 +65,7 @@ defmodule Blog.Content.Post do
     }
   end
 
-  @spec get_by_slug(any()) :: any()
+  @spec get_by_slug(String.t()) :: t() | nil
   def get_by_slug(slug) do
     # First check file-based posts
     case all() |> Enum.find(&(&1.slug == slug)) do

--- a/lib/blog/content/tag.ex
+++ b/lib/blog/content/tag.ex
@@ -1,3 +1,5 @@
 defmodule Blog.Content.Tag do
+  @type t :: %__MODULE__{name: String.t() | nil}
+
   defstruct [:name]
 end


### PR DESCRIPTION
Part of the gradual-typing pass (see `PROCESS.md`). Branches from main now that the Assay foundation (#14) is merged, so this is verified with Dialyzer.

Adds `@type`/`@spec` coverage to the `Blog.Content` subsystem:
- `Blog.Content.Tag` — `@type t`
- `Blog.Content.Post` — struct `@type t`, `all/0 :: [t()]`, and tightened `get_by_slug/1` from `any() -> any()` to `String.t() -> t() | nil`
- `Blog.Content.ImageGenerator` — `ensure_post_image/1 :: String.t() | nil`
- `Blog.Content` — `post_summary` type, specs on `list_posts/0` and `categorize_posts/1`

**Verified:** `mix compile --warnings-as-errors` clean, `mix assay` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)