### PR TITLE
Phase 3 (types): bookmarks subsystem @specs

### DIFF
--- a/lib/blog/bookmarks/bookmark.ex
+++ b/lib/blog/bookmarks/bookmark.ex
@@ -31,6 +31,7 @@ defmodule Blog.Bookmarks.Bookmark do
   Creates a new bookmark struct with the given attributes.
   Automatically generates an ID and timestamp if not provided.
   """
+  @spec new(map() | keyword()) :: t()
   def new(attrs \\ %{}) do
     attrs = Map.new(attrs)
 
@@ -50,6 +51,7 @@ defmodule Blog.Bookmarks.Bookmark do
   Validates a bookmark struct.
   Returns {:ok, bookmark} if valid, {:error, reason} if invalid.
   """
+  @spec validate(t()) :: {:ok, t()} | {:error, String.t()}
   def validate(%__MODULE__{} = bookmark) do
     cond do
       is_nil(bookmark.url) or bookmark.url == "" ->

--- a/lib/blog/bookmarks/store.ex
+++ b/lib/blog/bookmarks/store.ex
@@ -4,6 +4,7 @@ defmodule Blog.Bookmarks.Store do
 
   @table_name :bookmarks_table
 
+  @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts) do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
@@ -13,6 +14,7 @@ defmodule Blog.Bookmarks.Store do
     {:ok, %{}}
   end
 
+  @spec add_bookmark(struct() | map()) :: {:ok, struct()} | {:error, String.t()}
   def add_bookmark(%Bookmark{} = bookmark) do
     case Bookmark.validate(bookmark) do
       {:ok, bookmark} ->
@@ -38,6 +40,14 @@ defmodule Blog.Bookmarks.Store do
   end
 
   # Chrome extension compatibility
+  @spec add_bookmark(
+          String.t() | nil,
+          String.t() | nil,
+          String.t() | nil,
+          [String.t()] | nil,
+          String.t() | nil,
+          String.t() | nil
+        ) :: {:ok, struct()} | {:error, String.t()}
   def add_bookmark(url, title, description, tags, favicon_url, user_id) do
     attrs = %{
       url: url,
@@ -53,6 +63,7 @@ defmodule Blog.Bookmarks.Store do
     |> add_bookmark()
   end
 
+  @spec get_bookmark(term()) :: {:ok, struct()} | {:error, :not_found}
   def get_bookmark(id) do
     case :ets.lookup(@table_name, id) do
       [{^id, bookmark}] -> {:ok, bookmark}
@@ -60,12 +71,14 @@ defmodule Blog.Bookmarks.Store do
     end
   end
 
+  @spec list_bookmarks(String.t()) :: [struct()]
   def list_bookmarks(user_id) do
     :ets.match_object(@table_name, {:_, %Bookmark{user_id: user_id}})
     |> Enum.map(fn {_id, bookmark} -> bookmark end)
     |> Enum.sort_by(& &1.inserted_at, {:desc, DateTime})
   end
 
+  @spec delete_bookmark(term()) :: :ok
   def delete_bookmark(id) do
     :ets.delete(@table_name, id)
 
@@ -78,6 +91,7 @@ defmodule Blog.Bookmarks.Store do
     :ok
   end
 
+  @spec search_bookmarks(String.t(), String.t()) :: [struct()]
   def search_bookmarks(user_id, query) do
     query = String.downcase(query)
 


### PR DESCRIPTION
Part of the gradual-typing pass (see `PROCESS.md`), branched from main on top of the merged Assay foundation (#14).

Adds `@type`/`@spec` coverage to the `bookmarks` subsystem. Each spec was written by reading the implementation and independently reviewed for accuracy.

**Verified:** `mix compile --warnings-as-errors` clean, `mix assay` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)