### PR TITLE
Phase 3 (types): comments subsystem @specs

### DIFF
--- a/lib/blog/comments.ex
+++ b/lib/blog/comments.ex
@@ -7,6 +7,7 @@ defmodule Blog.Comments do
   alias Blog.Comments.Comment
 
   @doc "List all comments for a post by slug, ordered by creation time"
+  @spec list_comments(String.t()) :: [struct()]
   def list_comments(post_slug) do
     Comment
     |> where([c], c.post_slug == ^post_slug)
@@ -15,6 +16,7 @@ defmodule Blog.Comments do
   end
 
   @doc "Create a new comment"
+  @spec create_comment(map()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def create_comment(attrs) do
     %Comment{}
     |> Comment.changeset(attrs)
@@ -22,12 +24,15 @@ defmodule Blog.Comments do
   end
 
   @doc "Get a comment by ID"
+  @spec get_comment(term()) :: struct() | nil
   def get_comment(id), do: Repo.get(Comment, id)
 
   @doc "Delete a comment"
+  @spec delete_comment(struct()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def delete_comment(%Comment{} = comment), do: Repo.delete(comment)
 
   @doc "Returns an empty changeset for form rendering"
+  @spec change_comment(struct(), map()) :: Ecto.Changeset.t()
   def change_comment(%Comment{} = comment, attrs \\ %{}) do
     Comment.changeset(comment, attrs)
   end

--- a/lib/blog/comments/comment.ex
+++ b/lib/blog/comments/comment.ex
@@ -2,6 +2,15 @@ defmodule Blog.Comments.Comment do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{
+          id: integer() | nil,
+          post_slug: String.t() | nil,
+          author_name: String.t() | nil,
+          content: String.t() | nil,
+          inserted_at: NaiveDateTime.t() | nil,
+          updated_at: NaiveDateTime.t() | nil
+        }
+
   schema "post_comments" do
     field :post_slug, :string
     field :author_name, :string
@@ -11,6 +20,7 @@ defmodule Blog.Comments.Comment do
   end
 
   @doc false
+  @spec changeset(t() | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   def changeset(comment, attrs) do
     comment
     |> cast(attrs, [:post_slug, :author_name, :content])


### PR DESCRIPTION
Part of the gradual-typing pass (see `PROCESS.md`), branched from main on top of the merged Assay foundation (#14).

Adds `@type`/`@spec` coverage to the `comments` subsystem. Each spec was written by reading the implementation and independently reviewed for accuracy.

**Verified:** `mix compile --warnings-as-errors` clean, `mix assay` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)