### PR TITLE
Phase 3 (types): editor subsystem @specs

### DIFF
--- a/lib/blog/editor.ex
+++ b/lib/blog/editor.ex
@@ -10,6 +10,7 @@ defmodule Blog.Editor do
   @doc """
   Lists all drafts, ordered by most recently updated.
   """
+  @spec list_drafts() :: [struct()]
   def list_drafts do
     Draft
     |> order_by(desc: :updated_at)
@@ -19,6 +20,7 @@ defmodule Blog.Editor do
   @doc """
   Lists drafts by status.
   """
+  @spec list_drafts_by_status(String.t()) :: [struct()]
   def list_drafts_by_status(status) do
     Draft
     |> where(status: ^status)
@@ -29,16 +31,19 @@ defmodule Blog.Editor do
   @doc """
   Gets a single draft by ID.
   """
+  @spec get_draft(integer() | String.t()) :: struct() | nil
   def get_draft(id), do: Repo.get(Draft, id)
 
   @doc """
   Gets a single draft by slug.
   """
+  @spec get_draft_by_slug(String.t()) :: struct() | nil
   def get_draft_by_slug(slug), do: Repo.get_by(Draft, slug: slug)
 
   @doc """
   Creates a new draft.
   """
+  @spec create_draft(map()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def create_draft(attrs \\ %{}) do
     %Draft{}
     |> Draft.changeset(attrs)
@@ -48,6 +53,7 @@ defmodule Blog.Editor do
   @doc """
   Updates a draft.
   """
+  @spec update_draft(struct(), map()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def update_draft(%Draft{} = draft, attrs) do
     draft
     |> Draft.changeset(attrs)
@@ -57,6 +63,7 @@ defmodule Blog.Editor do
   @doc """
   Deletes a draft.
   """
+  @spec delete_draft(struct()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def delete_draft(%Draft{} = draft) do
     Repo.delete(draft)
   end
@@ -64,6 +71,7 @@ defmodule Blog.Editor do
   @doc """
   Returns an `%Ecto.Changeset{}` for tracking draft changes.
   """
+  @spec change_draft(struct(), map()) :: Ecto.Changeset.t()
   def change_draft(%Draft{} = draft, attrs \\ %{}) do
     Draft.changeset(draft, attrs)
   end
@@ -72,6 +80,7 @@ defmodule Blog.Editor do
   Publishes a draft by changing its status to "published".
   Requires author name and email.
   """
+  @spec publish_draft(struct(), map()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def publish_draft(%Draft{} = draft, attrs \\ %{}) do
     draft
     |> Draft.publish_changeset(Map.merge(attrs, %{status: "published"}))
@@ -81,6 +90,7 @@ defmodule Blog.Editor do
   @doc """
   Lists all published drafts (guest posts).
   """
+  @spec list_published() :: [struct()]
   def list_published do
     Draft
     |> where(status: "published")
@@ -95,6 +105,7 @@ defmodule Blog.Editor do
   - Bluesky post embeds via ::bsky[url] syntax
   - YouTube video embeds via ::youtube[url] syntax
   """
+  @spec render_markdown(String.t() | nil) :: String.t()
   def render_markdown(nil), do: ""
   def render_markdown(""), do: ""
 

--- a/lib/blog/editor/draft.ex
+++ b/lib/blog/editor/draft.ex
@@ -2,6 +2,19 @@ defmodule Blog.Editor.Draft do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{
+          id: integer() | nil,
+          title: String.t() | nil,
+          slug: String.t() | nil,
+          content: String.t() | nil,
+          status: String.t() | nil,
+          author_id: String.t() | nil,
+          author_name: String.t() | nil,
+          author_email: String.t() | nil,
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+
   schema "drafts" do
     field :title, :string
     field :slug, :string
@@ -15,6 +28,7 @@ defmodule Blog.Editor.Draft do
   end
 
   @doc false
+  @spec changeset(t() | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   def changeset(draft, attrs) do
     draft
     |> cast(attrs, [:title, :slug, :content, :status, :author_id, :author_name, :author_email])
@@ -25,6 +39,7 @@ defmodule Blog.Editor.Draft do
   end
 
   @doc "Changeset for publishing - requires author info"
+  @spec publish_changeset(t() | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   def publish_changeset(draft, attrs) do
     draft
     |> cast(attrs, [:title, :slug, :content, :status, :author_name, :author_email])


### PR DESCRIPTION
Part of the gradual-typing pass (see `PROCESS.md`), branched from main on top of the merged Assay foundation (#14).

Adds `@type`/`@spec` coverage to the `editor` subsystem. Each spec was written by reading the implementation and independently reviewed for accuracy.

**Verified:** `mix compile --warnings-as-errors` clean, `mix assay` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)