### PR TITLE
Phase 3 (types): chat subsystem @specs

### DIFF
--- a/lib/blog/chat.ex
+++ b/lib/blog/chat.ex
@@ -8,6 +8,7 @@ defmodule Blog.Chat do
 
   @pubsub_topic "terminal_chat"
 
+  @spec topic() :: String.t()
   def topic, do: @pubsub_topic
 
   # ============================================================================
@@ -23,6 +24,8 @@ defmodule Blog.Chat do
   3. If screen_name is taken by different IP, append number suffix
   4. Create new chatter if none exists for this IP
   """
+  @spec find_or_create_chatter(String.t(), String.t() | nil) ::
+          {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def find_or_create_chatter(screen_name, ip_address) do
     ip_hash = hash_ip(ip_address)
     screen_name = String.trim(screen_name)
@@ -43,11 +46,13 @@ defmodule Blog.Chat do
   end
 
   @doc "Get a chatter by their IP hash (for returning visitor detection)"
+  @spec get_chatter_by_ip(String.t() | nil) :: struct() | nil
   def get_chatter_by_ip(ip_hash) do
     Repo.get_by(Chatter, ip_hash: ip_hash)
   end
 
   @doc "Get a chatter by screen name"
+  @spec get_chatter_by_name(String.t()) :: struct() | nil
   def get_chatter_by_name(screen_name) do
     Repo.get_by(Chatter, screen_name: screen_name)
   end
@@ -96,6 +101,7 @@ defmodule Blog.Chat do
   end
 
   @doc "Hash an IP address for privacy (SHA256)"
+  @spec hash_ip(term()) :: String.t() | nil
   def hash_ip(ip_address) when is_binary(ip_address) do
     :crypto.hash(:sha256, ip_address)
     |> Base.encode16(case: :lower)
@@ -108,6 +114,7 @@ defmodule Blog.Chat do
   # ============================================================================
 
   @doc "List recent messages for a room with preloaded chatters"
+  @spec list_messages(String.t(), non_neg_integer()) :: [struct()]
   def list_messages(room \\ "terminal", limit \\ 50) do
     Message
     |> where([m], m.room == ^room)
@@ -118,6 +125,8 @@ defmodule Blog.Chat do
   end
 
   @doc "Create a new message and broadcast it"
+  @spec create_message(struct(), String.t(), String.t()) ::
+          {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def create_message(%Chatter{} = chatter, content, room \\ "terminal") do
     attrs = %{
       content: String.trim(content),
@@ -145,6 +154,7 @@ defmodule Blog.Chat do
   # ============================================================================
 
   @doc "Get online chatters (for buddy list display)"
+  @spec list_online_chatters(map()) :: [map()]
   def list_online_chatters(presence_list) do
     presence_list
     |> Enum.map(fn {_id, %{metas: [meta | _]}} -> meta end)
@@ -155,18 +165,23 @@ defmodule Blog.Chat do
   # ============================================================================
 
   @doc "Backwards compatibility - no-op, Postgres doesn't need ETS initialization"
+  @spec ensure_started() :: :ok
   def ensure_started, do: :ok
 
   @doc "Backwards compatibility - alias for list_messages"
+  @spec get_messages(String.t()) :: [struct()]
   def get_messages(room), do: list_messages(room)
 
   @doc "Backwards compatibility - banned words stub (not implemented in Postgres version)"
+  @spec add_banned_word(term()) :: {:ok, String.t()}
   def add_banned_word(_word), do: {:ok, ""}
 
   @doc "Backwards compatibility - banned words check stub"
+  @spec check_for_banned_words(term()) :: {:ok, term()}
   def check_for_banned_words(message), do: {:ok, message}
 
   @doc "Backwards compatibility - save message from old format"
+  @spec save_message(map()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def save_message(%{sender_name: name, sender_color: color, content: content, room: room}) do
     # For backwards compat, create an anonymous chatter if needed
     {:ok, chatter} = find_or_create_anonymous_chatter(name, color)

--- a/lib/blog/chat/chatter.ex
+++ b/lib/blog/chat/chatter.ex
@@ -2,6 +2,16 @@ defmodule Blog.Chat.Chatter do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{
+          id: integer() | nil,
+          screen_name: String.t() | nil,
+          ip_hash: String.t() | nil,
+          color: String.t() | nil,
+          messages: [struct()] | Ecto.Association.NotLoaded.t(),
+          inserted_at: NaiveDateTime.t() | nil,
+          updated_at: NaiveDateTime.t() | nil
+        }
+
   schema "chatters" do
     field :screen_name, :string
     field :ip_hash, :string
@@ -13,6 +23,7 @@ defmodule Blog.Chat.Chatter do
   end
 
   @doc false
+  @spec changeset(t() | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   def changeset(chatter, attrs) do
     chatter
     |> cast(attrs, [:screen_name, :ip_hash, :color])
@@ -22,6 +33,7 @@ defmodule Blog.Chat.Chatter do
   end
 
   @doc "Generate a random chat color in HSL format"
+  @spec random_color() :: String.t()
   def random_color do
     hue = :rand.uniform(360)
     "hsl(#{hue}, 70%, 40%)"

--- a/lib/blog/chat/message.ex
+++ b/lib/blog/chat/message.ex
@@ -2,6 +2,16 @@ defmodule Blog.Chat.Message do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{
+          id: integer() | nil,
+          content: String.t() | nil,
+          room: String.t() | nil,
+          chatter_id: integer() | nil,
+          chatter: struct() | Ecto.Association.NotLoaded.t() | nil,
+          inserted_at: NaiveDateTime.t() | nil,
+          updated_at: NaiveDateTime.t() | nil
+        }
+
   schema "chat_messages" do
     field :content, :string
     field :room, :string, default: "terminal"
@@ -12,6 +22,7 @@ defmodule Blog.Chat.Message do
   end
 
   @doc false
+  @spec changeset(t() | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   def changeset(message, attrs) do
     message
     |> cast(attrs, [:content, :room, :chatter_id])

--- a/lib/blog/chat/message_store.ex
+++ b/lib/blog/chat/message_store.ex
@@ -18,6 +18,7 @@ defmodule Blog.Chat.MessageStore do
 
   Should be called when the application starts.
   """
+  @spec init() :: :ok
   def init do
     # Create ETS table for messages if it doesn't exist
     if :ets.info(@table_name) == :undefined do
@@ -44,6 +45,7 @@ defmodule Blog.Chat.MessageStore do
   in descending order (most recent first). Message visibility is calculated dynamically
   by the LiveView and not stored in the ETS table.
   """
+  @spec store_message(map()) :: :ok
   def store_message(message) do
     # We use negative timestamp as key to get descending order
     timestamp_key = -DateTime.to_unix(message.timestamp, :microsecond)
@@ -66,6 +68,7 @@ defmodule Blog.Chat.MessageStore do
 
   Returns a list of messages, sorted by timestamp (newest first).
   """
+  @spec get_recent_messages(non_neg_integer()) :: [map()]
   def get_recent_messages(limit \\ @max_messages) do
     # Get messages ordered by timestamp (newest first)
     case :ets.info(@table_name) do
@@ -84,6 +87,7 @@ defmodule Blog.Chat.MessageStore do
   @doc """
   Adds a word to the global allowed words list.
   """
+  @spec add_allowed_word(term()) :: :ok
   def add_allowed_word(word) do
     current_words = get_allowed_words()
     new_words = MapSet.put(current_words, word)
@@ -98,6 +102,7 @@ defmodule Blog.Chat.MessageStore do
   @doc """
   Removes a word from the global allowed words list.
   """
+  @spec remove_allowed_word(term()) :: :ok
   def remove_allowed_word(word) do
     current_words = get_allowed_words()
     new_words = MapSet.delete(current_words, word)
@@ -115,6 +120,7 @@ defmodule Blog.Chat.MessageStore do
   Returns a MapSet of allowed words. If no global list exists,
   returns an empty MapSet and initializes one.
   """
+  @spec get_allowed_words() :: MapSet.t()
   def get_allowed_words do
     case :ets.lookup(@allowed_words_table, @global_words_key) do
       [{@global_words_key, allowed_words}] ->
@@ -129,11 +135,13 @@ defmodule Blog.Chat.MessageStore do
   end
 
   # For backwards compatibility - will get the global list
+  @spec get_allowed_words(term()) :: MapSet.t()
   def get_allowed_words(_user_id) do
     get_allowed_words()
   end
 
   # For backwards compatibility - will update the global list
+  @spec store_allowed_words(term(), MapSet.t()) :: :ok
   def store_allowed_words(_user_id, allowed_words) do
     :ets.insert(@allowed_words_table, {@global_words_key, allowed_words})
 
@@ -165,5 +173,6 @@ defmodule Blog.Chat.MessageStore do
   @doc """
   Returns the topic name for PubSub subscriptions.
   """
+  @spec topic() :: String.t()
   def topic, do: @topic
 end

--- a/lib/blog/chat/presence.ex
+++ b/lib/blog/chat/presence.ex
@@ -12,14 +12,22 @@ defmodule Blog.Chat.Presence do
 
   @presence_topic "allowed_chat:presence"
 
+  @typedoc """
+  Map of presences keyed by the tracked presence key (user id),
+  each value holding a list of metadata maps.
+  """
+  @type presences :: %{optional(String.t()) => %{metas: [map()]}}
+
   @doc """
   Returns the topic used for presence tracking.
   """
+  @spec topic() :: String.t()
   def topic, do: @presence_topic
 
   @doc """
   Tracks a user's presence when they connect to the chat.
   """
+  @spec track_user(String.t()) :: {:ok, binary()} | {:error, term()}
   def track_user(user_id) do
     __MODULE__.track(
       self(),
@@ -35,6 +43,7 @@ defmodule Blog.Chat.Presence do
   @doc """
   Gets the list of online users with their metadata.
   """
+  @spec list_online_users() :: presences()
   def list_online_users do
     __MODULE__.list(@presence_topic)
   end
@@ -44,6 +53,7 @@ defmodule Blog.Chat.Presence do
 
   Safely handles the case where the presence tracker is not yet initialized.
   """
+  @spec count_online_users() :: non_neg_integer()
   def count_online_users do
     try do
       @presence_topic


### PR DESCRIPTION
Part of the gradual-typing pass (see `PROCESS.md`), branched from main on top of the merged Assay foundation (#14).

Adds `@type`/`@spec` coverage to the `chat` subsystem. Each spec was written by reading the implementation and independently reviewed for accuracy.

**Verified:** `mix compile --warnings-as-errors` clean, `mix assay` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)