### PR TITLE
Phase 3 (types): collage_maker subsystem @specs

### DIFF
--- a/lib/blog/collage_maker.ex
+++ b/lib/blog/collage_maker.ex
@@ -3,43 +3,52 @@ defmodule Blog.CollageMaker do
   alias Blog.Repo
   alias Blog.CollageMaker.{Collage, Image}
 
+  @spec create_collage(map()) :: {:ok, Collage.t()} | {:error, Ecto.Changeset.t()}
   def create_collage(attrs) do
     %Collage{}
     |> Collage.changeset(attrs)
     |> Repo.insert()
   end
 
+  @spec get_collage!(term()) :: Collage.t()
   def get_collage!(id), do: Repo.get!(Collage, id)
 
+  @spec get_collage(term()) :: Collage.t() | nil
   def get_collage(id), do: Repo.get(Collage, id)
 
+  @spec get_collage_by_token(String.t()) :: Collage.t() | nil
   def get_collage_by_token(token) do
     Repo.get_by(Collage, share_token: token)
   end
 
+  @spec update_collage(Collage.t(), map()) :: {:ok, Collage.t()} | {:error, Ecto.Changeset.t()}
   def update_collage(%Collage{} = collage, attrs) do
     collage
     |> Collage.changeset(attrs)
     |> Repo.update()
   end
 
+  @spec add_image(map()) :: {:ok, Image.t()} | {:error, Ecto.Changeset.t()}
   def add_image(attrs) do
     %Image{}
     |> Image.changeset(attrs)
     |> Repo.insert()
   end
 
+  @spec update_image(Image.t(), map()) :: {:ok, Image.t()} | {:error, Ecto.Changeset.t()}
   def update_image(%Image{} = image, attrs) do
     image
     |> Image.changeset(attrs)
     |> Repo.update()
   end
 
+  @spec list_images(term()) :: [Image.t()]
   def list_images(collage_id) do
     from(i in Image, where: i.collage_id == ^collage_id, order_by: i.position)
     |> Repo.all()
   end
 
+  @spec cleanup_expired() :: non_neg_integer()
   def cleanup_expired do
     now = DateTime.utc_now()
 
@@ -66,6 +75,7 @@ defmodule Blog.CollageMaker do
     length(expired)
   end
 
+  @spec count_recent(String.t(), integer()) :: non_neg_integer()
   def count_recent(ip_hash, minutes) do
     cutoff = DateTime.add(DateTime.utc_now(), -minutes * 60, :second)
 

--- a/lib/blog/collage_maker/cleanup.ex
+++ b/lib/blog/collage_maker/cleanup.ex
@@ -4,6 +4,7 @@ defmodule Blog.CollageMaker.Cleanup do
 
   @cleanup_interval :timer.minutes(30)
 
+  @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts) do
     GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
   end

--- a/lib/blog/collage_maker/collage.ex
+++ b/lib/blog/collage_maker/collage.ex
@@ -2,6 +2,25 @@ defmodule Blog.CollageMaker.Collage do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{
+          id: integer() | nil,
+          status: String.t() | nil,
+          columns: integer() | nil,
+          cell_size: integer() | nil,
+          image_count: integer() | nil,
+          collage_s3_key: String.t() | nil,
+          collage_width: integer() | nil,
+          collage_height: integer() | nil,
+          collage_file_size: integer() | nil,
+          ip_hash: String.t() | nil,
+          error_message: String.t() | nil,
+          share_token: String.t() | nil,
+          expires_at: DateTime.t() | nil,
+          images: [struct()] | Ecto.Association.NotLoaded.t(),
+          inserted_at: NaiveDateTime.t() | nil,
+          updated_at: NaiveDateTime.t() | nil
+        }
+
   schema "collage_maker_collages" do
     field :status, :string, default: "uploading"
     field :columns, :integer, default: 3
@@ -21,6 +40,7 @@ defmodule Blog.CollageMaker.Collage do
     timestamps()
   end
 
+  @spec changeset(t() | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   def changeset(collage, attrs) do
     collage
     |> cast(attrs, [:status, :columns, :cell_size, :image_count, :collage_s3_key,
@@ -31,6 +51,7 @@ defmodule Blog.CollageMaker.Collage do
     |> unique_constraint(:share_token)
   end
 
+  @spec generate_share_token() :: String.t()
   def generate_share_token do
     :crypto.strong_rand_bytes(4) |> Base.encode16(case: :lower)
   end

--- a/lib/blog/collage_maker/image.ex
+++ b/lib/blog/collage_maker/image.ex
@@ -2,6 +2,21 @@ defmodule Blog.CollageMaker.Image do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{
+          id: integer() | nil,
+          position: integer() | nil,
+          original_s3_key: String.t() | nil,
+          cropped_s3_key: String.t() | nil,
+          original_width: integer() | nil,
+          original_height: integer() | nil,
+          content_type: String.t() | nil,
+          file_size: integer() | nil,
+          collage_id: integer() | nil,
+          collage: Ecto.Association.NotLoaded.t() | struct() | nil,
+          inserted_at: NaiveDateTime.t() | nil,
+          updated_at: NaiveDateTime.t() | nil
+        }
+
   schema "collage_maker_images" do
     field :position, :integer
     field :original_s3_key, :string
@@ -16,6 +31,7 @@ defmodule Blog.CollageMaker.Image do
     timestamps()
   end
 
+  @spec changeset(t() | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   def changeset(image, attrs) do
     image
     |> cast(attrs, [:collage_id, :position, :original_s3_key, :cropped_s3_key,

--- a/lib/blog/collage_maker/image_processor.ex
+++ b/lib/blog/collage_maker/image_processor.ex
@@ -3,6 +3,8 @@ defmodule Blog.CollageMaker.ImageProcessor do
 
   @max_cell_size 2048
 
+  @spec get_dimensions(String.t()) ::
+          {:ok, non_neg_integer(), non_neg_integer()} | {:error, String.t()}
   def get_dimensions(path) do
     case System.cmd("identify", ["-format", "%w %h", path], stderr_to_stdout: true) do
       {output, 0} ->
@@ -14,6 +16,7 @@ defmodule Blog.CollageMaker.ImageProcessor do
     end
   end
 
+  @spec compute_cell_size([map()]) :: non_neg_integer()
   def compute_cell_size(images) do
     min_dim =
       images
@@ -23,6 +26,8 @@ defmodule Blog.CollageMaker.ImageProcessor do
     min(min_dim, @max_cell_size)
   end
 
+  @spec square_crop(String.t(), String.t(), non_neg_integer()) ::
+          {:ok, String.t()} | {:error, String.t()}
   def square_crop(input_path, output_path, cell_size) do
     case get_dimensions(input_path) do
       {:ok, w, h} ->
@@ -48,6 +53,8 @@ defmodule Blog.CollageMaker.ImageProcessor do
     end
   end
 
+  @spec stitch_collage([String.t()], pos_integer(), non_neg_integer(), String.t()) ::
+          {:ok, String.t(), non_neg_integer(), non_neg_integer()} | {:error, String.t()}
   def stitch_collage(image_paths, columns, cell_size, output_path) do
     total = length(image_paths)
     rows = ceil(total / columns)

--- a/lib/blog/collage_maker/processor.ex
+++ b/lib/blog/collage_maker/processor.ex
@@ -7,10 +7,12 @@ defmodule Blog.CollageMaker.Processor do
 
   @max_concurrent 2
 
+  @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts) do
     GenServer.start_link(__MODULE__, %{active: 0}, name: __MODULE__)
   end
 
+  @spec process_collage(term()) :: :ok
   def process_collage(collage_id) do
     GenServer.cast(__MODULE__, {:process, collage_id})
   end

--- a/lib/blog/collage_maker/rate_limiter.ex
+++ b/lib/blog/collage_maker/rate_limiter.ex
@@ -3,6 +3,7 @@ defmodule Blog.CollageMaker.RateLimiter do
   @hourly_limit 5
   @daily_limit 20
 
+  @spec check(String.t()) :: :ok | {:error, String.t()}
   def check(ip_hash) do
     now = System.system_time(:second)
     cleanup_old_entries(ip_hash, now)
@@ -18,6 +19,7 @@ defmodule Blog.CollageMaker.RateLimiter do
     end
   end
 
+  @spec record(String.t()) :: true
   def record(ip_hash) do
     now = System.system_time(:second)
     entries = get_entries(ip_hash)


### PR DESCRIPTION
Part of the gradual-typing pass (see `PROCESS.md`), branched from the merged Assay baseline. Adds `@type`/`@spec` to the `collage_maker` subsystem; each spec written from the implementation and independently reviewed.

**Verified:** `mix compile --warnings-as-errors` clean, `mix assay` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)