### PR TITLE
Phase 3 (types): finder subsystem @specs

### DIFF
--- a/lib/blog/finder.ex
+++ b/lib/blog/finder.ex
@@ -5,6 +5,7 @@ defmodule Blog.Finder do
 
   # === Public Queries (used by TerminalLive) ===
 
+  @spec list_sections_with_items() :: [struct()]
   def list_sections_with_items do
     Section
     |> where([s], s.visible == true)
@@ -15,6 +16,7 @@ defmodule Blog.Finder do
 
   # === Section CRUD (admin) ===
 
+  @spec list_sections() :: [struct()]
   def list_sections do
     Section
     |> order_by([s], asc: s.sort_order)
@@ -22,51 +24,65 @@ defmodule Blog.Finder do
     |> Repo.all()
   end
 
+  @spec get_section!(term()) :: struct()
   def get_section!(id), do: Repo.get!(Section, id) |> Repo.preload(items: from(i in Item, order_by: [asc: i.sort_order]))
 
+  @spec create_section(map()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def create_section(attrs) do
     %Section{}
     |> Section.changeset(attrs)
     |> Repo.insert()
   end
 
+  @spec update_section(struct(), map()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def update_section(%Section{} = section, attrs) do
     section
     |> Section.changeset(attrs)
     |> Repo.update()
   end
 
+  @spec delete_section(struct()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def delete_section(%Section{} = section), do: Repo.delete(section)
 
+  @spec change_section(struct(), map()) :: Ecto.Changeset.t()
   def change_section(%Section{} = section, attrs \\ %{}), do: Section.changeset(section, attrs)
 
   # === Item CRUD (admin) ===
 
+  @spec get_item!(term()) :: struct()
   def get_item!(id), do: Repo.get!(Item, id)
 
+  @spec create_item(map()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def create_item(attrs) do
     %Item{}
     |> Item.changeset(attrs)
     |> Repo.insert()
   end
 
+  @spec update_item(struct(), map()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def update_item(%Item{} = item, attrs) do
     item
     |> Item.changeset(attrs)
     |> Repo.update()
   end
 
+  @spec delete_item(struct()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def delete_item(%Item{} = item), do: Repo.delete(item)
 
+  @spec change_item(struct(), map()) :: Ecto.Changeset.t()
   def change_item(%Item{} = item, attrs \\ %{}), do: Item.changeset(item, attrs)
 
   # === Reordering ===
 
+  @spec reorder_section(term(), :up | :down) ::
+          :ok | {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def reorder_section(section_id, direction) when direction in [:up, :down] do
     sections = Repo.all(from(s in Section, order_by: [asc: s.sort_order]))
     reorder_in_list(sections, section_id, direction, &update_section/2)
   end
 
+  @spec reorder_item(term(), :up | :down) ::
+          :ok | {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def reorder_item(item_id, direction) when direction in [:up, :down] do
     item = get_item!(item_id)
     items = Repo.all(from(i in Item, where: i.section_id == ^item.section_id, order_by: [asc: i.sort_order]))

--- a/lib/blog/finder/item.ex
+++ b/lib/blog/finder/item.ex
@@ -2,6 +2,22 @@ defmodule Blog.Finder.Item do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{
+          id: integer() | nil,
+          name: String.t() | nil,
+          icon: String.t() | nil,
+          path: String.t() | nil,
+          sort_order: integer() | nil,
+          joyride_target: String.t() | nil,
+          action: String.t() | nil,
+          description: String.t() | nil,
+          visible: boolean() | nil,
+          section_id: integer() | nil,
+          section: Ecto.Association.NotLoaded.t() | struct() | nil,
+          inserted_at: NaiveDateTime.t() | nil,
+          updated_at: NaiveDateTime.t() | nil
+        }
+
   schema "finder_items" do
     field :name, :string
     field :icon, :string
@@ -17,6 +33,7 @@ defmodule Blog.Finder.Item do
     timestamps()
   end
 
+  @spec changeset(t() | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   def changeset(item, attrs) do
     item
     |> cast(attrs, [:name, :icon, :path, :sort_order, :joyride_target, :action, :description, :visible, :section_id])

--- a/lib/blog/finder/section.ex
+++ b/lib/blog/finder/section.ex
@@ -2,6 +2,18 @@ defmodule Blog.Finder.Section do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{
+          id: integer() | nil,
+          name: String.t() | nil,
+          label: String.t() | nil,
+          sort_order: integer() | nil,
+          joyride_target: String.t() | nil,
+          visible: boolean() | nil,
+          items: [struct()] | Ecto.Association.NotLoaded.t(),
+          inserted_at: NaiveDateTime.t() | nil,
+          updated_at: NaiveDateTime.t() | nil
+        }
+
   schema "finder_sections" do
     field :name, :string
     field :label, :string
@@ -14,6 +26,7 @@ defmodule Blog.Finder.Section do
     timestamps()
   end
 
+  @spec changeset(t() | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   def changeset(section, attrs) do
     section
     |> cast(attrs, [:name, :label, :sort_order, :joyride_target, :visible])


### PR DESCRIPTION
Part of the gradual-typing pass (see `PROCESS.md`), branched from the merged Assay baseline. Adds `@type`/`@spec` to the `finder` subsystem; each spec written from the implementation and independently reviewed.

**Verified:** `mix compile --warnings-as-errors` clean, `mix assay` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)