### PR TITLE
Phase 3 (types): github subsystem @specs

### DIFF
--- a/lib/blog/github/work_log.ex
+++ b/lib/blog/github/work_log.ex
@@ -3,6 +3,7 @@ defmodule Blog.GitHub.WorkLog do
   alias Blog.Repo
   alias Blog.GitHub.WorkLogCommit
 
+  @spec upsert_from_compare(String.t(), String.t(), String.t(), map()) :: :ok
   def upsert_from_compare(repo, branch, event_id, compare_data) do
     commits = compare_data.commits
     stats = compare_data.stats
@@ -25,6 +26,7 @@ defmodule Blog.GitHub.WorkLog do
     end)
   end
 
+  @spec list_recent() :: [map()]
   def list_recent do
     WorkLogCommit
     |> where([c], c.additions >= 10 or c.deletions >= 10)

--- a/lib/blog/github/work_log_commit.ex
+++ b/lib/blog/github/work_log_commit.ex
@@ -2,6 +2,20 @@ defmodule Blog.GitHub.WorkLogCommit do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{
+          id: integer() | nil,
+          event_id: String.t() | nil,
+          repo: String.t() | nil,
+          branch: String.t() | nil,
+          sha: String.t() | nil,
+          message: String.t() | nil,
+          additions: integer() | nil,
+          deletions: integer() | nil,
+          committed_at: DateTime.t() | nil,
+          inserted_at: NaiveDateTime.t() | nil,
+          updated_at: NaiveDateTime.t() | nil
+        }
+
   schema "work_log_commits" do
     field :event_id, :string
     field :repo, :string
@@ -16,6 +30,7 @@ defmodule Blog.GitHub.WorkLogCommit do
   end
 
   @doc false
+  @spec changeset(t() | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   def changeset(commit, attrs) do
     commit
     |> cast(attrs, [:event_id, :repo, :branch, :sha, :message, :additions, :deletions, :committed_at])

--- a/lib/blog/github/work_log_poller.ex
+++ b/lib/blog/github/work_log_poller.ex
@@ -8,10 +8,12 @@ defmodule Blog.GitHub.WorkLogPoller do
   @topic "github:work_log"
   @max_compares_per_cycle 10
 
+  @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
+  @spec get_events() :: [map()]
   def get_events do
     Blog.GitHub.WorkLog.list_recent()
   end


### PR DESCRIPTION
Part of the gradual-typing pass (see `PROCESS.md`), branched from the merged Assay baseline. Adds `@type`/`@spec` to the `github` subsystem; each spec written from the implementation and independently reviewed.

**Verified:** `mix compile --warnings-as-errors` clean, `mix assay` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)