### PR TITLE
Phase 3 (types): museum subsystem @specs

### DIFF
--- a/lib/blog/museum/icons.ex
+++ b/lib/blog/museum/icons.ex
@@ -4,6 +4,7 @@ defmodule Blog.Museum.Icons do
   32x32 pixel grid rendered as SVG, classic Macintosh style.
   """
 
+  @spec get(String.t()) :: String.t()
   def get(slug), do: Map.get(icons(), slug, default())
 
   defp default do
@@ -753,6 +754,7 @@ defmodule Blog.Museum.Icons do
   Converts a pixel art text grid to an SVG string.
   '#' = black pixel, '.' = transparent
   """
+  @spec pixels(String.t()) :: String.t()
   def pixels(text) do
     rows =
       text

--- a/lib/blog/museum/project.ex
+++ b/lib/blog/museum/project.ex
@@ -2,6 +2,26 @@ defmodule Blog.Museum.Project do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{
+          id: integer() | nil,
+          slug: String.t() | nil,
+          title: String.t() | nil,
+          tagline: String.t() | nil,
+          description: String.t() | nil,
+          category: String.t() | nil,
+          tech_stack: [String.t()],
+          github_repos: [map()],
+          internal_path: String.t() | nil,
+          external_url: String.t() | nil,
+          pixel_art_path: String.t() | nil,
+          emoji: String.t() | nil,
+          color: String.t() | nil,
+          sort_order: integer() | nil,
+          visible: boolean() | nil,
+          inserted_at: NaiveDateTime.t() | nil,
+          updated_at: NaiveDateTime.t() | nil
+        }
+
   schema "museum_projects" do
     field :slug, :string
     field :title, :string
@@ -21,6 +41,7 @@ defmodule Blog.Museum.Project do
     timestamps()
   end
 
+  @spec changeset(t() | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   def changeset(project, attrs) do
     project
     |> cast(attrs, [

--- a/lib/blog/museum/projects.ex
+++ b/lib/blog/museum/projects.ex
@@ -5,6 +5,7 @@ defmodule Blog.Museum.Projects do
 
   # === Public Queries (used by TerminalLive) ===
 
+  @spec all() :: [struct()]
   def all do
     Project
     |> where([p], p.visible == true)
@@ -12,10 +13,12 @@ defmodule Blog.Museum.Projects do
     |> Repo.all()
   end
 
+  @spec get_by_slug(String.t()) :: struct() | nil
   def get_by_slug(slug) do
     Repo.get_by(Project, slug: slug, visible: true)
   end
 
+  @spec categories() :: [String.t()]
   def categories do
     Project
     |> where([p], p.visible == true)
@@ -25,6 +28,7 @@ defmodule Blog.Museum.Projects do
     |> Repo.all()
   end
 
+  @spec by_category(String.t()) :: [struct()]
   def by_category(category) do
     Project
     |> where([p], p.visible == true and p.category == ^category)
@@ -34,32 +38,39 @@ defmodule Blog.Museum.Projects do
 
   # === Admin CRUD ===
 
+  @spec list_projects() :: [struct()]
   def list_projects do
     Project
     |> order_by([p], asc: p.sort_order)
     |> Repo.all()
   end
 
+  @spec get_project!(term()) :: struct()
   def get_project!(id), do: Repo.get!(Project, id)
 
+  @spec create_project(map()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def create_project(attrs) do
     %Project{}
     |> Project.changeset(attrs)
     |> Repo.insert()
   end
 
+  @spec update_project(struct(), map()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def update_project(%Project{} = project, attrs) do
     project
     |> Project.changeset(attrs)
     |> Repo.update()
   end
 
+  @spec delete_project(struct()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def delete_project(%Project{} = project), do: Repo.delete(project)
 
+  @spec change_project(struct(), map()) :: Ecto.Changeset.t()
   def change_project(%Project{} = project, attrs \\ %{}), do: Project.changeset(project, attrs)
 
   # === Reordering ===
 
+  @spec bulk_reorder([integer() | String.t()]) :: {:ok, term()} | {:error, term()}
   def bulk_reorder(ids) when is_list(ids) do
     Repo.transaction(fn ->
       ids
@@ -72,6 +83,8 @@ defmodule Blog.Museum.Projects do
     end)
   end
 
+  @spec reorder_project(term(), :up | :down) ::
+          :ok | {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def reorder_project(project_id, direction) when direction in [:up, :down] do
     projects = Repo.all(from(p in Project, order_by: [asc: p.sort_order]))
     reorder_in_list(projects, project_id, direction)


### PR DESCRIPTION
Part of the gradual-typing pass (see `PROCESS.md`), branched from the merged Assay baseline. Adds `@type`/`@spec` to the `museum` subsystem; each spec written from the implementation and independently reviewed.

**Verified:** `mix compile --warnings-as-errors` clean, `mix assay` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)