### PR TITLE
Phase 3 (types): poke_around subsystem @specs

### DIFF
--- a/lib/blog/poke_around/ai/axon/text_classifier.ex
+++ b/lib/blog/poke_around/ai/axon/text_classifier.ex
@@ -63,6 +63,8 @@ defmodule Blog.PokeAround.AI.Axon.TextClassifier do
   - vocab: map of word -> index
   - tag_index: map of tag_slug -> index
   """
+  @spec prepare_training_data(keyword()) ::
+          {Nx.Tensor.t(), Nx.Tensor.t(), map(), map()}
   def prepare_training_data(opts \\ []) do
     min_tag_count = opts[:min_tag_count] || @min_tag_count
 
@@ -95,6 +97,8 @@ defmodule Blog.PokeAround.AI.Axon.TextClassifier do
 
   This uses the manually curated training data with consolidated tags.
   """
+  @spec prepare_training_data_from_file(keyword()) ::
+          {Nx.Tensor.t(), Nx.Tensor.t(), map(), map()}
   def prepare_training_data_from_file(opts \\ []) do
     min_tag_count = opts[:min_tag_count] || 2
     file_path = opts[:file] || "priv/ml/training_data.json"
@@ -267,6 +271,7 @@ defmodule Blog.PokeAround.AI.Axon.TextClassifier do
   @doc """
   Simple word-level tokenizer.
   """
+  @spec tokenize(term()) :: [String.t()]
   def tokenize(text) when is_binary(text) do
     text
     |> String.downcase()
@@ -285,6 +290,7 @@ defmodule Blog.PokeAround.AI.Axon.TextClassifier do
   @doc """
   Build the Axon model for multi-label classification.
   """
+  @spec build_model(keyword()) :: Axon.t()
   def build_model(opts \\ []) do
     vocab_size = opts[:vocab_size] || raise "vocab_size required"
     num_tags = opts[:num_tags] || raise "num_tags required"
@@ -309,6 +315,7 @@ defmodule Blog.PokeAround.AI.Axon.TextClassifier do
   @doc """
   Train the model on the prepared data.
   """
+  @spec train(Axon.t(), Nx.Tensor.t(), Nx.Tensor.t(), keyword()) :: map()
   def train(model, inputs, labels, opts \\ []) do
     epochs = opts[:epochs] || 20
     batch_size = opts[:batch_size] || 32
@@ -350,6 +357,7 @@ defmodule Blog.PokeAround.AI.Axon.TextClassifier do
   @doc """
   Calculate multi-label accuracy (IoU style) for evaluation.
   """
+  @spec multi_label_accuracy(Nx.Tensor.t(), Nx.Tensor.t()) :: number()
   def multi_label_accuracy(y_pred, y_true) do
     # Threshold predictions
     predictions = Nx.greater(y_pred, 0.5)
@@ -373,6 +381,7 @@ defmodule Blog.PokeAround.AI.Axon.TextClassifier do
   @doc """
   Save trained model, vocabulary, and tag index.
   """
+  @spec save_model(map(), map(), map(), String.t()) :: :ok
   def save_model(model_state, vocab, tag_index, path) do
     File.mkdir_p!(path)
 
@@ -403,6 +412,7 @@ defmodule Blog.PokeAround.AI.Axon.TextClassifier do
   @doc """
   Load a trained model.
   """
+  @spec load_model(String.t()) :: {Axon.t(), map(), map(), map()}
   def load_model(path) do
     # Load metadata
     metadata =
@@ -438,6 +448,7 @@ defmodule Blog.PokeAround.AI.Axon.TextClassifier do
   Simple prediction without serving (for testing).
   Returns top-5 predictions sorted by probability.
   """
+  @spec predict_simple(Axon.t(), map(), term(), map(), map()) :: [{String.t(), float()}]
   def predict_simple(model, state, text, vocab, tag_index) do
     tokens = tokenize(text)
     encoded = encode_sequence(tokens, vocab)
@@ -462,6 +473,7 @@ defmodule Blog.PokeAround.AI.Axon.TextClassifier do
   @doc """
   Get predictions above threshold for production use.
   """
+  @spec predict_tags(Axon.t(), map(), term(), map(), map(), number()) :: [String.t()]
   def predict_tags(model, state, text, vocab, tag_index, threshold \\ @prediction_threshold) do
     tokens = tokenize(text)
     encoded = encode_sequence(tokens, vocab)

--- a/lib/blog/poke_around/ai/axon_tagger.ex
+++ b/lib/blog/poke_around/ai/axon_tagger.ex
@@ -59,10 +59,24 @@ defmodule Blog.PokeAround.AI.AxonTagger do
     :stats
   ]
 
+  @type t :: %__MODULE__{
+          model: term(),
+          state: term(),
+          vocab: map(),
+          tag_index: map(),
+          threshold: number(),
+          auto_tag: boolean(),
+          interval: non_neg_integer(),
+          batch_size: non_neg_integer(),
+          langs: [String.t()],
+          stats: map()
+        }
+
   # ---------------------------------------------------------------------------
   # Public API
   # ---------------------------------------------------------------------------
 
+  @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, opts, name: opts[:name] || __MODULE__)
   end
@@ -71,6 +85,7 @@ defmodule Blog.PokeAround.AI.AxonTagger do
   Predict tags for a single link.
   Returns {:ok, [tags]} or {:error, reason}
   """
+  @spec predict(GenServer.server(), map()) :: {:ok, term()}
   def predict(server \\ __MODULE__, link) do
     GenServer.call(server, {:predict, link}, 30_000)
   end
@@ -78,6 +93,7 @@ defmodule Blog.PokeAround.AI.AxonTagger do
   @doc """
   Get tagger statistics.
   """
+  @spec stats(GenServer.server()) :: map()
   def stats(server \\ __MODULE__) do
     GenServer.call(server, :stats)
   end
@@ -85,6 +101,7 @@ defmodule Blog.PokeAround.AI.AxonTagger do
   @doc """
   Manually trigger a batch of tagging.
   """
+  @spec process_batch(GenServer.server()) :: :ok
   def process_batch(server \\ __MODULE__) do
     GenServer.cast(server, :process_batch)
   end

--- a/lib/blog/poke_around/ai/supervisor.ex
+++ b/lib/blog/poke_around/ai/supervisor.ex
@@ -24,6 +24,7 @@ defmodule Blog.PokeAround.AI.Supervisor do
 
   require Logger
 
+  @spec start_link(keyword()) :: Supervisor.on_start()
   def start_link(opts \\ []) do
     name = opts[:name] || __MODULE__
     Supervisor.start_link(__MODULE__, opts, name: name)

--- a/lib/blog/poke_around/bluesky/extractor.ex
+++ b/lib/blog/poke_around/bluesky/extractor.ex
@@ -88,6 +88,13 @@ defmodule Blog.PokeAround.Bluesky.Extractor do
 
   @stats_interval_ms 30_000
 
+  @type t :: %__MODULE__{
+          started_at: DateTime.t() | nil,
+          posts_processed: non_neg_integer(),
+          links_found: non_neg_integer(),
+          links_qualified: non_neg_integer()
+        }
+
   defstruct [
     :started_at,
     posts_processed: 0,

--- a/lib/blog/poke_around/bluesky/firehose.ex
+++ b/lib/blog/poke_around/bluesky/firehose.ex
@@ -37,10 +37,28 @@ defmodule Blog.PokeAround.Bluesky.Firehose do
     posts_received: 0
   ]
 
+  @type t :: %__MODULE__{
+          url: String.t() | nil,
+          started_at: DateTime.t() | nil,
+          messages_received: non_neg_integer(),
+          posts_received: non_neg_integer()
+        }
+
+  @typedoc """
+  Stats snapshot returned by `get_stats/1`.
+  """
+  @type stats :: %{
+          messages_received: non_neg_integer(),
+          posts_received: non_neg_integer(),
+          uptime_seconds: integer(),
+          messages_per_second: float()
+        }
+
   # ---------------------------------------------------------------------------
   # Public API
   # ---------------------------------------------------------------------------
 
+  @spec start_link(keyword()) :: {:ok, pid()} | {:error, term()}
   def start_link(opts \\ []) do
     url = opts[:url] || config(:url, @turbostream_url)
     name = opts[:name] || __MODULE__
@@ -54,6 +72,7 @@ defmodule Blog.PokeAround.Bluesky.Firehose do
     WebSockex.start_link(url, __MODULE__, state, name: name, handle_initial_conn_failure: true)
   end
 
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
   def child_spec(opts) do
     %{
       id: __MODULE__,
@@ -66,6 +85,7 @@ defmodule Blog.PokeAround.Bluesky.Firehose do
   @doc """
   Get current stats from the firehose.
   """
+  @spec get_stats(GenServer.server()) :: stats() | {:error, :timeout}
   def get_stats(server \\ __MODULE__) do
     WebSockex.cast(server, {:get_stats, self()})
 

--- a/lib/blog/poke_around/bluesky/supervisor.ex
+++ b/lib/blog/poke_around/bluesky/supervisor.ex
@@ -16,6 +16,7 @@ defmodule Blog.PokeAround.Bluesky.Supervisor do
 
   require Logger
 
+  @spec start_link(keyword()) :: Supervisor.on_start()
   def start_link(opts) do
     Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
   end
@@ -40,6 +41,7 @@ defmodule Blog.PokeAround.Bluesky.Supervisor do
   @doc """
   Check if the firehose is enabled.
   """
+  @spec enabled?() :: boolean()
   def enabled? do
     Application.get_env(:blog, __MODULE__, [])
     |> Keyword.get(:enabled, true)

--- a/lib/blog/poke_around/link.ex
+++ b/lib/blog/poke_around/link.ex
@@ -6,7 +6,30 @@ defmodule Blog.PokeAround.Link do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @type t :: %__MODULE__{}
+  @type t :: %__MODULE__{
+          id: integer() | nil,
+          url: String.t() | nil,
+          url_hash: String.t() | nil,
+          post_uri: String.t() | nil,
+          post_text: String.t() | nil,
+          post_created_at: DateTime.t() | nil,
+          author_did: String.t() | nil,
+          author_handle: String.t() | nil,
+          author_display_name: String.t() | nil,
+          author_followers_count: integer() | nil,
+          score: integer() | nil,
+          title: String.t() | nil,
+          description: String.t() | nil,
+          image_url: String.t() | nil,
+          domain: String.t() | nil,
+          tags: [String.t()] | nil,
+          langs: [String.t()] | nil,
+          stumble_count: integer() | nil,
+          tagged_at: DateTime.t() | nil,
+          normalized_tags: [struct()] | Ecto.Association.NotLoaded.t() | nil,
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
 
   schema "pa_links" do
     field :url, :string

--- a/lib/blog/poke_around/link_tag.ex
+++ b/lib/blog/poke_around/link_tag.ex
@@ -6,6 +6,17 @@ defmodule Blog.PokeAround.LinkTag do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{
+          link_id: integer() | nil,
+          link: Ecto.Association.NotLoaded.t() | struct() | nil,
+          tag_id: integer() | nil,
+          tag: Ecto.Association.NotLoaded.t() | struct() | nil,
+          source: String.t() | nil,
+          confidence: float() | nil,
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+
   @primary_key false
   schema "pa_link_tags" do
     belongs_to :link, Blog.PokeAround.Link
@@ -20,6 +31,7 @@ defmodule Blog.PokeAround.LinkTag do
   @required_fields [:link_id, :tag_id]
   @optional_fields [:source, :confidence]
 
+  @spec changeset(t() | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   def changeset(link_tag, attrs) do
     link_tag
     |> cast(attrs, @required_fields ++ @optional_fields)

--- a/lib/blog/poke_around/links.ex
+++ b/lib/blog/poke_around/links.ex
@@ -13,6 +13,8 @@ defmodule Blog.PokeAround.Links do
   Returns `{:ok, link}` or `{:error, changeset}`.
   If the link already exists (by URL hash), returns `{:ok, :exists}`.
   """
+  @spec store_link(map()) ::
+          {:ok, struct()} | {:ok, :exists} | {:error, Ecto.Changeset.t()}
   def store_link(attrs) do
     url = attrs[:url] || attrs["url"]
     url_hash = Link.hash_url(url)
@@ -53,6 +55,7 @@ defmodule Blog.PokeAround.Links do
   - `:domain` - filter by domain
   - `:tags` - filter by tags (any match)
   """
+  @spec random_link(keyword()) :: struct() | nil
   def random_link(opts \\ []) do
     min_score = opts[:min_score] || 0
     exclude_ids = opts[:exclude_ids] || []
@@ -95,6 +98,7 @@ defmodule Blog.PokeAround.Links do
   - `:exclude_ids` - list of link IDs to exclude
   - `:langs` - filter by languages (any match)
   """
+  @spec random_links(non_neg_integer(), keyword()) :: [struct()]
   def random_links(count, opts \\ []) do
     min_score = opts[:min_score] || 0
     exclude_ids = opts[:exclude_ids] || []
@@ -128,6 +132,7 @@ defmodule Blog.PokeAround.Links do
   @doc """
   Increment the stumble count for a link.
   """
+  @spec increment_stumble_count(term()) :: {non_neg_integer(), nil | [term()]}
   def increment_stumble_count(link_id) do
     from(l in Link, where: l.id == ^link_id)
     |> Repo.update_all(inc: [stumble_count: 1])
@@ -136,11 +141,13 @@ defmodule Blog.PokeAround.Links do
   @doc """
   Get a link by ID.
   """
+  @spec get_link(term()) :: struct() | nil
   def get_link(id), do: Repo.get(Link, id)
 
   @doc """
   Get a link by URL.
   """
+  @spec get_link_by_url(String.t()) :: struct() | nil
   def get_link_by_url(url) do
     url_hash = Link.hash_url(url)
     Repo.get_by(Link, url_hash: url_hash)
@@ -149,6 +156,7 @@ defmodule Blog.PokeAround.Links do
   @doc """
   List links with pagination.
   """
+  @spec list_links(keyword()) :: [struct()]
   def list_links(opts \\ []) do
     page = opts[:page] || 1
     per_page = opts[:per_page] || 20
@@ -165,6 +173,7 @@ defmodule Blog.PokeAround.Links do
   @doc """
   Count total links.
   """
+  @spec count_links() :: non_neg_integer()
   def count_links do
     Repo.aggregate(Link, :count)
   end
@@ -172,6 +181,7 @@ defmodule Blog.PokeAround.Links do
   @doc """
   Get top domains by link count.
   """
+  @spec top_domains(non_neg_integer()) :: [{String.t() | nil, non_neg_integer()}]
   def top_domains(limit \\ 10) do
     from(l in Link,
       group_by: l.domain,

--- a/lib/blog/poke_around/supervisor.ex
+++ b/lib/blog/poke_around/supervisor.ex
@@ -34,6 +34,7 @@ defmodule Blog.PokeAround.Supervisor do
 
   require Logger
 
+  @spec start_link(term()) :: Supervisor.on_start()
   def start_link(opts) do
     Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
   end
@@ -58,6 +59,7 @@ defmodule Blog.PokeAround.Supervisor do
   @doc """
   Check if the poke_around system is enabled.
   """
+  @spec enabled?() :: term()
   def enabled? do
     Application.get_env(:blog, __MODULE__, [])
     |> Keyword.get(:enabled, true)

--- a/lib/blog/poke_around/tag.ex
+++ b/lib/blog/poke_around/tag.ex
@@ -6,6 +6,16 @@ defmodule Blog.PokeAround.Tag do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{
+          id: integer() | nil,
+          name: String.t() | nil,
+          slug: String.t() | nil,
+          usage_count: integer() | nil,
+          links: [struct()] | Ecto.Association.NotLoaded.t(),
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+
   schema "pa_tags" do
     field :name, :string
     field :slug, :string
@@ -19,6 +29,7 @@ defmodule Blog.PokeAround.Tag do
   @required_fields [:name, :slug]
   @optional_fields [:usage_count]
 
+  @spec changeset(t() | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   def changeset(tag, attrs) do
     tag
     |> cast(attrs, @required_fields ++ @optional_fields)
@@ -30,6 +41,7 @@ defmodule Blog.PokeAround.Tag do
   Generate a slug from a tag name.
   Lowercases and replaces spaces with hyphens.
   """
+  @spec slugify(String.t()) :: String.t()
   def slugify(name) when is_binary(name) do
     name
     |> String.downcase()

--- a/lib/blog/poke_around/tags.ex
+++ b/lib/blog/poke_around/tags.ex
@@ -10,6 +10,7 @@ defmodule Blog.PokeAround.Tags do
   @doc """
   Get or create a tag by name.
   """
+  @spec get_or_create_tag(String.t()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def get_or_create_tag(name) when is_binary(name) do
     slug = Tag.slugify(name)
 
@@ -30,6 +31,7 @@ defmodule Blog.PokeAround.Tags do
   Takes a link and a list of tag names, creates any missing tags,
   and associates them with the link.
   """
+  @spec tag_link(struct(), [String.t()], keyword()) :: {:ok, :ok} | {:error, term()}
   def tag_link(link, tag_names, opts \\ []) when is_list(tag_names) do
     source = opts[:source] || "axon"
     confidence = opts[:confidence]
@@ -89,6 +91,7 @@ defmodule Blog.PokeAround.Tags do
   @doc """
   Get all tags for a link.
   """
+  @spec get_tags_for_link(term()) :: [struct()]
   def get_tags_for_link(link_id) do
     from(t in Tag,
       join: lt in LinkTag,
@@ -102,6 +105,7 @@ defmodule Blog.PokeAround.Tags do
   @doc """
   Get popular tags.
   """
+  @spec popular_tags(integer()) :: [struct()]
   def popular_tags(limit \\ 20) do
     from(t in Tag,
       order_by: [desc: t.usage_count],
@@ -122,6 +126,7 @@ defmodule Blog.PokeAround.Tags do
   - `:rules` - List of filter rules (see apply_filter_rules/2)
   - `:match_mode` - :all (default) or :any for rule matching
   """
+  @spec list_tags(keyword()) :: [struct()]
   def list_tags(opts \\ []) do
     # Support legacy options
     search = opts[:search]
@@ -187,6 +192,7 @@ defmodule Blog.PokeAround.Tags do
   Name operators: :contains, :starts_with, :ends_with, :equals
   Created operators: :last_n_days, :before, :after
   """
+  @spec apply_filter_rules(Ecto.Queryable.t(), [map()], :all | :any) :: Ecto.Queryable.t()
   def apply_filter_rules(query, [], _match_mode), do: query
 
   def apply_filter_rules(query, rules, :all) do
@@ -301,6 +307,7 @@ defmodule Blog.PokeAround.Tags do
   @doc """
   Count total tags.
   """
+  @spec count_tags() :: integer()
   def count_tags do
     Repo.aggregate(Tag, :count)
   end
@@ -313,6 +320,7 @@ defmodule Blog.PokeAround.Tags do
   - `:order` - :newest (default) or :score
   - `:langs` - Filter by languages (empty list = all)
   """
+  @spec links_by_tag(String.t(), keyword()) :: [struct()]
   def links_by_tag(slug, opts \\ []) do
     limit = opts[:limit] || 50
     order = opts[:order] || :newest
@@ -345,6 +353,7 @@ defmodule Blog.PokeAround.Tags do
   @doc """
   Get a tag by slug.
   """
+  @spec get_tag_by_slug(String.t()) :: struct() | nil
   def get_tag_by_slug(slug) do
     Repo.get_by(Tag, slug: slug)
   end
@@ -355,6 +364,7 @@ defmodule Blog.PokeAround.Tags do
   Options:
   - `:langs` - Filter by languages (default: ["en"] for English only)
   """
+  @spec untagged_links(integer(), keyword()) :: [struct()]
   def untagged_links(limit \\ 10, opts \\ []) do
     langs = opts[:langs] || ["en"]
 
@@ -377,6 +387,7 @@ defmodule Blog.PokeAround.Tags do
   Options:
   - `:langs` - Filter by languages (default: ["en"] for English only)
   """
+  @spec count_untagged(keyword()) :: integer()
   def count_untagged(opts \\ []) do
     langs = opts[:langs] || ["en"]
 


### PR DESCRIPTION
Part of the gradual-typing pass (see `PROCESS.md`), branched from the merged Assay baseline. Adds `@type`/`@spec` to the `poke_around` subsystem; each spec written from the implementation and independently reviewed.

**Verified:** `mix compile --warnings-as-errors` clean, `mix assay` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)