### PR TITLE
Phase 3 (types): role_call subsystem @specs

### DIFF
--- a/lib/blog/role_call.ex
+++ b/lib/blog/role_call.ex
@@ -9,6 +9,7 @@ defmodule Blog.RoleCall do
 
   # ============ Shows ============
 
+  @spec search_shows(String.t(), keyword()) :: [struct()]
   def search_shows(query, opts \\ []) when is_binary(query) do
     limit = Keyword.get(opts, :limit, 20)
     exclude_ids = Keyword.get(opts, :exclude_ids, [])
@@ -22,8 +23,10 @@ defmodule Blog.RoleCall do
     |> Repo.all()
   end
 
+  @spec get_show(term()) :: struct() | nil
   def get_show(id), do: Repo.get(Show, id)
 
+  @spec get_show_with_credits(term()) :: struct() | nil
   def get_show_with_credits(id) do
     from(s in Show,
       where: s.id == ^id,
@@ -42,6 +45,7 @@ defmodule Blog.RoleCall do
     )
   end
 
+  @spec get_random_shows(keyword()) :: [map()]
   def get_random_shows(opts \\ []) do
     limit = Keyword.get(opts, :limit, 12)
     exclude_ids = Keyword.get(opts, :exclude_ids, [])
@@ -60,8 +64,10 @@ defmodule Blog.RoleCall do
 
   # ============ People ============
 
+  @spec get_person(term()) :: struct() | nil
   def get_person(id), do: Repo.get(Person, id)
 
+  @spec get_person_with_shows(term()) :: struct() | nil
   def get_person_with_shows(id) do
     from(p in Person,
       where: p.id == ^id,
@@ -80,6 +86,7 @@ defmodule Blog.RoleCall do
 
   # ============ Writers & Recommendations ============
 
+  @spec get_show_writers(term()) :: [struct()]
   def get_show_writers(show_id) do
     from(c in Credit,
       join: p in assoc(c, :person),
@@ -94,6 +101,7 @@ defmodule Blog.RoleCall do
     |> Enum.map(& &1.person)
   end
 
+  @spec get_writer_shows(term(), keyword()) :: [struct()]
   def get_writer_shows(person_id, opts \\ []) do
     exclude_ids = Keyword.get(opts, :exclude_ids, [])
 
@@ -113,6 +121,7 @@ defmodule Blog.RoleCall do
   Get recommendations based on writers from liked shows.
   Returns shows by the same writers, ranked by how many liked writers worked on them.
   """
+  @spec get_recommendations([term()], keyword()) :: [map()]
   def get_recommendations(liked_show_ids, opts \\ []) when is_list(liked_show_ids) do
     limit = Keyword.get(opts, :limit, 20)
     exclude_ids = Keyword.get(opts, :exclude_ids, [])
@@ -154,25 +163,31 @@ defmodule Blog.RoleCall do
 
   # ============ Data Import ============
 
+  @spec import_show(map()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def import_show(attrs) do
     %Show{}
     |> Show.changeset(attrs)
     |> Repo.insert(on_conflict: :replace_all, conflict_target: :id)
   end
 
+  @spec import_person(map()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def import_person(attrs) do
     %Person{}
     |> Person.changeset(attrs)
     |> Repo.insert(on_conflict: :replace_all, conflict_target: :id)
   end
 
+  @spec import_credit(map()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def import_credit(attrs) do
     %Credit{}
     |> Credit.changeset(attrs)
     |> Repo.insert(on_conflict: :nothing)
   end
 
+  @spec count_shows() :: non_neg_integer()
   def count_shows, do: Repo.aggregate(Show, :count)
+
+  @spec count_people() :: non_neg_integer()
   def count_people, do: Repo.aggregate(Person, :count)
 
   # ============ Helpers ============

--- a/lib/blog/role_call/credit.ex
+++ b/lib/blog/role_call/credit.ex
@@ -2,6 +2,16 @@ defmodule Blog.RoleCall.Credit do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{
+          id: integer() | nil,
+          role: String.t() | nil,
+          details: String.t() | nil,
+          show_id: String.t() | nil,
+          show: struct() | Ecto.Association.NotLoaded.t() | nil,
+          person_id: String.t() | nil,
+          person: struct() | Ecto.Association.NotLoaded.t() | nil
+        }
+
   @primary_key {:id, :id, autogenerate: true}
   schema "rc_credits" do
     field :role, :string
@@ -11,6 +21,7 @@ defmodule Blog.RoleCall.Credit do
     belongs_to :person, Blog.RoleCall.Person, type: :string
   end
 
+  @spec changeset(t() | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   def changeset(credit, attrs) do
     credit
     |> cast(attrs, [:show_id, :person_id, :role, :details])

--- a/lib/blog/role_call/person.ex
+++ b/lib/blog/role_call/person.ex
@@ -2,6 +2,17 @@ defmodule Blog.RoleCall.Person do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{
+          id: String.t() | nil,
+          name: String.t() | nil,
+          image_url: String.t() | nil,
+          scraped_at: DateTime.t() | nil,
+          credits: [struct()] | Ecto.Association.NotLoaded.t(),
+          shows: [struct()] | Ecto.Association.NotLoaded.t(),
+          inserted_at: NaiveDateTime.t() | nil,
+          updated_at: NaiveDateTime.t() | nil
+        }
+
   @primary_key {:id, :string, autogenerate: false}
   schema "rc_people" do
     field :name, :string
@@ -14,6 +25,7 @@ defmodule Blog.RoleCall.Person do
     timestamps()
   end
 
+  @spec changeset(t() | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   def changeset(person, attrs) do
     person
     |> cast(attrs, [:id, :name, :image_url, :scraped_at])

--- a/lib/blog/role_call/show.ex
+++ b/lib/blog/role_call/show.ex
@@ -2,6 +2,22 @@ defmodule Blog.RoleCall.Show do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{
+          id: String.t() | nil,
+          title: String.t() | nil,
+          year_start: integer() | nil,
+          year_end: integer() | nil,
+          imdb_rating: float() | nil,
+          genres: String.t() | nil,
+          description: String.t() | nil,
+          image_url: String.t() | nil,
+          scraped_at: DateTime.t() | nil,
+          credits: [struct()] | Ecto.Association.NotLoaded.t(),
+          people: [struct()] | Ecto.Association.NotLoaded.t(),
+          inserted_at: NaiveDateTime.t() | nil,
+          updated_at: NaiveDateTime.t() | nil
+        }
+
   @primary_key {:id, :string, autogenerate: false}
   schema "rc_shows" do
     field :title, :string
@@ -19,12 +35,14 @@ defmodule Blog.RoleCall.Show do
     timestamps()
   end
 
+  @spec changeset(t() | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   def changeset(show, attrs) do
     show
     |> cast(attrs, [:id, :title, :year_start, :year_end, :imdb_rating, :genres, :description, :image_url, :scraped_at])
     |> validate_required([:id, :title])
   end
 
+  @spec genres_list(t()) :: list()
   def genres_list(%__MODULE__{genres: nil}), do: []
   def genres_list(%__MODULE__{genres: genres}) do
     case Jason.decode(genres) do


### PR DESCRIPTION
Part of the gradual-typing pass (see `PROCESS.md`), branched from the merged Assay baseline. Adds `@type`/`@spec` to the `role_call` subsystem; each spec written from the implementation and independently reviewed.

**Verified:** `mix compile --warnings-as-errors` clean, `mix assay` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)