### PR TITLE
Phase 3 (types): smart_steps subsystem @specs

### DIFF
--- a/lib/blog/smart_steps/game_logic.ex
+++ b/lib/blog/smart_steps/game_logic.ex
@@ -7,11 +7,14 @@ defmodule Blog.SmartSteps.GameLogic do
   alias Blog.SmartSteps.Types.{GameState, LevelData, Metrics, Message, Choice, Scenario}
 
   @doc "Create a fresh initial game state."
+  @spec create_initial_state() :: GameState.t()
   def create_initial_state do
     %GameState{}
   end
 
   @doc "Build a LevelData record for one round of play."
+  @spec build_level_data(integer(), String.t(), String.t(), Choice.t(), String.t(), Metrics.t()) ::
+          LevelData.t()
   def build_level_data(level, scenario_id, scenario_title, %Choice{} = choice, notes, %Metrics{} = metrics) do
     %LevelData{
       level: level,
@@ -27,6 +30,7 @@ defmodule Blog.SmartSteps.GameLogic do
   end
 
   @doc "Check if the game should end."
+  @spec game_over?(String.t(), Scenario.t() | nil, integer(), integer()) :: boolean()
   def game_over?(next_scenario_id, next_scenario, current_level, max_levels) do
     next_scenario_id == "GAME_OVER" ||
       (next_scenario != nil && next_scenario.is_game_over == true) ||
@@ -39,6 +43,23 @@ defmodule Blog.SmartSteps.GameLogic do
   `get_next_scenario` is a function that looks up a scenario by ID.
   Returns `{:ok, result}` or `{:error, reason}`.
   """
+  @spec process_choice(
+          GameState.t(),
+          Scenario.t(),
+          integer(),
+          String.t(),
+          Metrics.t(),
+          (String.t() -> Scenario.t() | nil)
+        ) ::
+          {:ok,
+           %{
+             level_data: LevelData.t(),
+             is_game_over: boolean(),
+             next_scenario_id: String.t(),
+             game_over_reason: String.t() | nil,
+             messages: [Message.t()]
+           }}
+          | {:error, String.t()}
   def process_choice(%GameState{} = state, %Scenario{} = scenario, choice_index, notes, %Metrics{} = metrics, get_next_scenario)
       when is_integer(choice_index) and is_function(get_next_scenario, 1) do
     case Enum.at(scenario.choices, choice_index) do
@@ -99,6 +120,7 @@ defmodule Blog.SmartSteps.GameLogic do
   end
 
   @doc "Generate a random 6-digit session ID."
+  @spec generate_session_id() :: String.t()
   def generate_session_id do
     (100_000 + :rand.uniform(900_000) - 1)
     |> Integer.to_string()

--- a/lib/blog/smart_steps/metrics.ex
+++ b/lib/blog/smart_steps/metrics.ex
@@ -9,6 +9,7 @@ defmodule Blog.SmartSteps.Metrics do
                 :relationship_skills, :decision_making, :self_advocacy]
 
   @doc "Return default metrics struct."
+  @spec default_metrics() :: struct()
   def default_metrics, do: %Metrics{}
 
   @doc """
@@ -16,6 +17,7 @@ defmodule Blog.SmartSteps.Metrics do
   Returns default metrics for an empty list.
   Rounds to 1 decimal place.
   """
+  @spec calculate_average([struct()]) :: struct()
   def calculate_average([]), do: %Metrics{}
 
   def calculate_average(level_data) when is_list(level_data) do

--- a/lib/blog/smart_steps/session.ex
+++ b/lib/blog/smart_steps/session.ex
@@ -2,6 +2,20 @@ defmodule Blog.SmartSteps.Session do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{
+          id: integer() | nil,
+          session_id: String.t() | nil,
+          title: String.t() | nil,
+          tree_id: String.t() | nil,
+          level_data: [map()],
+          average_metrics: map(),
+          outcome_type: String.t() | nil,
+          total_levels: integer() | nil,
+          completed: boolean(),
+          inserted_at: NaiveDateTime.t() | nil,
+          updated_at: NaiveDateTime.t() | nil
+        }
+
   schema "smart_steps_sessions" do
     field :session_id, :string
     field :title, :string
@@ -16,6 +30,7 @@ defmodule Blog.SmartSteps.Session do
   end
 
   @doc false
+  @spec changeset(t() | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   def changeset(session, attrs) do
     session
     |> cast(attrs, [:session_id, :title, :tree_id, :level_data, :average_metrics,

--- a/lib/blog/smart_steps/session_server.ex
+++ b/lib/blog/smart_steps/session_server.ex
@@ -13,26 +13,33 @@ defmodule Blog.SmartSteps.SessionServer do
   # Client API
   # ============================================
 
+  @spec start_link({String.t(), String.t(), Types.scenario_role()}) :: GenServer.on_start()
   def start_link({session_id, tree_id, role}) do
     GenServer.start_link(__MODULE__, {session_id, tree_id, role}, name: via(session_id))
   end
 
+  @spec get_state(String.t()) :: GameState.t()
   def get_state(session_id) do
     GenServer.call(via(session_id), :get_state)
   end
 
+  @spec select_choice(String.t(), integer()) :: :ok
   def select_choice(session_id, index) do
     GenServer.call(via(session_id), {:select_choice, index})
   end
 
+  @spec continue_to_discussion(String.t()) :: :ok | {:error, :invalid_state}
   def continue_to_discussion(session_id) do
     GenServer.call(via(session_id), :continue_to_discussion)
   end
 
+  @spec proceed_from_discussion(String.t(), String.t(), Metrics.t()) ::
+          {:ok, GameState.t()} | {:error, term()}
   def proceed_from_discussion(session_id, notes, %Metrics{} = metrics) do
     GenServer.call(via(session_id), {:proceed_from_discussion, notes, metrics})
   end
 
+  @spec session_exists?(String.t()) :: boolean()
   def session_exists?(session_id) do
     case Registry.lookup(Blog.SmartSteps.SessionRegistry, session_id) do
       [{_pid, _}] -> true

--- a/lib/blog/smart_steps/story_demo.ex
+++ b/lib/blog/smart_steps/story_demo.ex
@@ -20,6 +20,7 @@ defmodule Blog.SmartSteps.StoryDemo do
   Weights: critical=5, high=4, medium=2, low=1.
   Optional `random` parameter should be in [0, 1).
   """
+  @spec pick_weighted_choice([Choice.t()], float() | nil) :: Choice.t()
   def pick_weighted_choice(choices, random \\ nil)
 
   def pick_weighted_choice([], _random),
@@ -55,6 +56,7 @@ defmodule Blog.SmartSteps.StoryDemo do
   Returns list of scenario IDs from start to game-over (max #{@max_steps} steps).
   Optional `random_fn` is a 0-arity function returning a float in [0, 1).
   """
+  @spec generate_random_path(ScenarioTree.t(), (-> float()) | nil) :: [String.t()]
   def generate_random_path(%ScenarioTree{} = tree, random_fn \\ nil) do
     rng = random_fn || fn -> :rand.uniform() end
     do_walk(tree.scenarios, tree.start_scenario_id, rng, [], 0)
@@ -87,6 +89,7 @@ defmodule Blog.SmartSteps.StoryDemo do
   end
 
   @doc "Get narrative transition text based on risk level."
+  @spec transition_text(Blog.SmartSteps.Types.risk_level()) :: String.t()
   def transition_text(:low), do: "Playing it safe..."
   def transition_text(:medium), do: "Trying to figure it out..."
   def transition_text(:high), do: "Things get harder..."

--- a/lib/blog/smart_steps/trees.ex
+++ b/lib/blog/smart_steps/trees.ex
@@ -25,16 +25,19 @@ defmodule Blog.SmartSteps.Trees do
   ]
 
   @doc "Return all scenario trees."
+  @spec all_trees() :: [struct()]
   def all_trees do
     Enum.map(@tree_modules, & &1.tree())
   end
 
   @doc "Get a scenario tree by ID."
+  @spec get_tree(String.t()) :: struct() | nil
   def get_tree(id) do
     Enum.find(all_trees(), fn tree -> tree.id == id end)
   end
 
   @doc "Get a specific scenario by ID, optionally within a specific tree."
+  @spec get_scenario(String.t(), String.t() | nil) :: struct() | nil
   def get_scenario(scenario_id, tree_id \\ nil) do
     trees =
       if tree_id do
@@ -52,6 +55,7 @@ defmodule Blog.SmartSteps.Trees do
   end
 
   @doc "Get the start scenario for a given tree."
+  @spec get_start_scenario(String.t()) :: struct() | nil
   def get_start_scenario(tree_id) do
     case get_tree(tree_id) do
       nil -> nil

--- a/lib/blog/smart_steps/trees/birthday_party.ex
+++ b/lib/blog/smart_steps/trees/birthday_party.ex
@@ -1,6 +1,11 @@
 defmodule Blog.SmartSteps.Trees.BirthdayParty do
+  @moduledoc """
+  Static scenario tree definition for "The Birthday Party" Smart Steps story.
+  """
+
   alias Blog.SmartSteps.Types.{ScenarioTree, Scenario, Choice}
 
+  @spec tree() :: ScenarioTree.t()
   def tree do
     %ScenarioTree{
       id: "birthday-party",

--- a/lib/blog/smart_steps/trees/cafeteria.ex
+++ b/lib/blog/smart_steps/trees/cafeteria.ex
@@ -1,6 +1,7 @@
 defmodule Blog.SmartSteps.Trees.Cafeteria do
   alias Blog.SmartSteps.Types.{ScenarioTree, Scenario, Choice}
 
+  @spec tree() :: struct()
   def tree do
     %ScenarioTree{
       id: "cafeteria",

--- a/lib/blog/smart_steps/trees/fire_drill.ex
+++ b/lib/blog/smart_steps/trees/fire_drill.ex
@@ -1,6 +1,11 @@
 defmodule Blog.SmartSteps.Trees.FireDrill do
+  @moduledoc """
+  Static definition of the "Fire Drill" scenario tree for Smart Steps.
+  """
+
   alias Blog.SmartSteps.Types.{ScenarioTree, Scenario, Choice}
 
+  @spec tree() :: ScenarioTree.t()
   def tree do
     %ScenarioTree{
       id: "fire-drill",

--- a/lib/blog/smart_steps/trees/group_project.ex
+++ b/lib/blog/smart_steps/trees/group_project.ex
@@ -1,6 +1,7 @@
 defmodule Blog.SmartSteps.Trees.GroupProject do
   alias Blog.SmartSteps.Types.{ScenarioTree, Scenario, Choice}
 
+  @spec tree() :: ScenarioTree.t()
   def tree do
     %ScenarioTree{
       id: "group-project",

--- a/lib/blog/smart_steps/trees/new_kid.ex
+++ b/lib/blog/smart_steps/trees/new_kid.ex
@@ -1,6 +1,7 @@
 defmodule Blog.SmartSteps.Trees.NewKid do
   alias Blog.SmartSteps.Types.{ScenarioTree, Scenario, Choice}
 
+  @spec tree() :: ScenarioTree.t()
   def tree do
     %ScenarioTree{
       id: "new-kid",

--- a/lib/blog/smart_steps/trees/playground.ex
+++ b/lib/blog/smart_steps/trees/playground.ex
@@ -1,6 +1,7 @@
 defmodule Blog.SmartSteps.Trees.Playground do
   alias Blog.SmartSteps.Types.{ScenarioTree, Scenario, Choice}
 
+  @spec tree() :: ScenarioTree.t()
   def tree do
     %ScenarioTree{
       id: "playground",

--- a/lib/blog/smart_steps/trees/substitute_teacher.ex
+++ b/lib/blog/smart_steps/trees/substitute_teacher.ex
@@ -1,6 +1,7 @@
 defmodule Blog.SmartSteps.Trees.SubstituteTeacher do
   alias Blog.SmartSteps.Types.{ScenarioTree, Scenario, Choice}
 
+  @spec tree() :: ScenarioTree.t()
   def tree do
     %ScenarioTree{
       id: "substitute-teacher",

--- a/lib/blog/smart_steps/types.ex
+++ b/lib/blog/smart_steps/types.ex
@@ -181,7 +181,10 @@ defmodule Blog.SmartSteps.Types do
     self_advocacy: "Self-advocacy"
   }
 
+  @spec metric_labels() :: %{atom() => String.t()}
   def metric_labels, do: @metric_labels
+
+  @spec default_metrics() :: Metrics.t()
   def default_metrics, do: %Metrics{}
 
   # ============================================
@@ -189,6 +192,7 @@ defmodule Blog.SmartSteps.Types do
   # ============================================
 
   @doc "Create a new message with a random UUID and current timestamp."
+  @spec create_message(message_type(), String.t()) :: Message.t()
   def create_message(type, content) when type in [:system, :user, :facilitator] do
     %Message{
       id: Ecto.UUID.generate(),
@@ -199,6 +203,7 @@ defmodule Blog.SmartSteps.Types do
   end
 
   @doc "Generate a random 6-digit session ID."
+  @spec generate_session_id() :: String.t()
   def generate_session_id do
     (100_000 + :rand.uniform(900_000) - 1)
     |> Integer.to_string()


### PR DESCRIPTION
Part of the gradual-typing pass (see `PROCESS.md`), branched from the merged Assay baseline. Adds `@type`/`@spec` to the `smart_steps` subsystem; each spec written from the implementation and independently reviewed.

**Verified:** `mix compile --warnings-as-errors` clean, `mix assay` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)