### PR TITLE
Phase 3 (types): thermal_printer subsystem @specs

### DIFF
--- a/lib/blog/thermal_printer.ex
+++ b/lib/blog/thermal_printer.ex
@@ -18,6 +18,7 @@ defmodule Blog.ThermalPrinter do
       # From raw binary data
       {:ok, dithered} = Blog.ThermalPrinter.process_image(image_binary)
   """
+  @spec process_upload(map()) :: {:ok, term()} | {:error, term()}
   def process_upload(upload_entry) do
     consume_uploaded_entry(upload_entry, fn %{path: path} ->
       binary = File.read!(path)
@@ -25,6 +26,7 @@ defmodule Blog.ThermalPrinter do
     end)
   end
 
+  @spec process_image(binary(), keyword()) :: {:ok, term()} | {:error, term()}
   def process_image(image_binary, opts \\ []) do
     width = Keyword.get(opts, :width, 384)
     
@@ -38,6 +40,7 @@ defmodule Blog.ThermalPrinter do
   @doc """
   Get a preview of the dithered image as a data URL for display in the browser.
   """
+  @spec get_preview(binary(), keyword()) :: {:ok, String.t()} | {:error, term()}
   def get_preview(image_binary, opts \\ []) do
     width = Keyword.get(opts, :width, 384)
     

--- a/lib/blog/thermal_printer/simple_png.ex
+++ b/lib/blog/thermal_printer/simple_png.ex
@@ -6,6 +6,8 @@ defmodule Blog.ThermalPrinter.SimplePNG do
 
   @png_signature <<137, 80, 78, 71, 13, 10, 26, 10>>
 
+  @spec decode(binary()) ::
+          {:ok, [integer()], non_neg_integer(), non_neg_integer()} | {:error, String.t()}
   def decode(binary) do
     with {:ok, chunks} <- validate_and_parse(binary),
          {:ok, ihdr} <- get_ihdr(chunks),


### PR DESCRIPTION
Part of the gradual-typing pass (see `PROCESS.md`), branched from the merged Assay baseline. Adds `@type`/`@spec` to the `thermal_printer` subsystem; each spec written from the implementation and independently reviewed.

**Verified:** `mix compile --warnings-as-errors` clean, `mix assay` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)