### PR TITLE
Phase 3 (types): wordle subsystem @specs

### DIFF
--- a/lib/blog/wordle/game.ex
+++ b/lib/blog/wordle/game.ex
@@ -19,6 +19,20 @@ defmodule Blog.Wordle.Game do
     field(:last_activity, :string, default: nil)
   end
 
+  @type t :: %__MODULE__{
+          session_id: String.t() | nil,
+          player_id: String.t() | nil,
+          target_word: String.t() | nil,
+          current_guess: String.t(),
+          guesses: [map()],
+          game_over: boolean(),
+          message: String.t() | nil,
+          used_letters: map(),
+          max_attempts: integer(),
+          hard_mode: boolean(),
+          last_activity: String.t() | nil
+        }
+
   @word_length 5
   @max_attempts 6
   @topic "wordle:games"
@@ -26,6 +40,7 @@ defmodule Blog.Wordle.Game do
   @doc """
   Creates a new game with a random target word.
   """
+  @spec new(String.t() | nil) :: t()
   def new(player_id \\ nil) do
     session_id = generate_session_id()
     player_id = player_id || "player-#{:rand.uniform(10000)}"
@@ -50,6 +65,7 @@ defmodule Blog.Wordle.Game do
   @doc """
   Validates and processes a changeset for the game.
   """
+  @spec changeset(t() | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   def changeset(game, attrs) do
     cast(game, attrs, [
       :session_id,
@@ -69,6 +85,7 @@ defmodule Blog.Wordle.Game do
   @doc """
   Handles keyboard input based on the current state of the game.
   """
+  @spec handle_key_press(t(), String.t()) :: {:ok, t()} | {:error, t()}
   def handle_key_press(game, key) do
     case {game.game_over, key, String.length(game.current_guess)} do
       {true, _key, _length} ->
@@ -109,6 +126,7 @@ defmodule Blog.Wordle.Game do
   @doc """
   Submits the current guess and updates the game state.
   """
+  @spec submit_guess(t()) :: {:ok, t()} | {:error, t()}
   def submit_guess(game) do
     guess = game.current_guess
 
@@ -172,6 +190,7 @@ defmodule Blog.Wordle.Game do
   @doc """
   Toggles hard mode, only allowed if no guesses have been made.
   """
+  @spec toggle_hard_mode(t()) :: {:ok, t()} | {:error, t()}
   def toggle_hard_mode(game) do
     if Enum.empty?(game.guesses) do
       game = %{
@@ -197,6 +216,7 @@ defmodule Blog.Wordle.Game do
   @doc """
   Resets the game with a new target word.
   """
+  @spec reset_game(t()) :: t()
   def reset_game(game) do
     game = %{
       game
@@ -216,11 +236,13 @@ defmodule Blog.Wordle.Game do
   @doc """
   Returns the PubSub topic for wordle games
   """
+  @spec topic() :: String.t()
   def topic, do: @topic
 
   @doc """
   Returns the specific topic for a single game
   """
+  @spec game_topic(String.t()) :: String.t()
   def game_topic(session_id), do: "#{@topic}:#{session_id}"
 
   defp broadcast_update(game) do

--- a/lib/blog/wordle/game_store.ex
+++ b/lib/blog/wordle/game_store.ex
@@ -12,6 +12,7 @@ defmodule Blog.Wordle.GameStore do
   # Seconds of inactivity for new games with no guesses
   @idle_threshold 60
 
+  @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(_opts \\ []) do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
@@ -62,6 +63,7 @@ defmodule Blog.Wordle.GameStore do
   @doc """
   Cleans up idle games that have no guesses and have been inactive for more than the threshold
   """
+  @spec cleanup_idle_empty_games() :: :ok
   def cleanup_idle_empty_games do
     now = DateTime.utc_now()
     threshold_seconds = @idle_threshold
@@ -103,6 +105,7 @@ defmodule Blog.Wordle.GameStore do
   @doc """
   Saves a game state to ETS
   """
+  @spec save_game(map()) :: map()
   def save_game(game) do
     # Don't store games with missing data
     if valid_game?(game) do
@@ -118,6 +121,7 @@ defmodule Blog.Wordle.GameStore do
   @doc """
   Gets a game by session ID
   """
+  @spec get_game(String.t()) :: map() | nil
   def get_game(session_id) do
     case :ets.lookup(@games_table, session_id) do
       [{^session_id, game}] -> game
@@ -128,6 +132,7 @@ defmodule Blog.Wordle.GameStore do
   @doc """
   Gets all active games
   """
+  @spec all_games() :: [map()]
   def all_games do
     :ets.tab2list(@games_table)
     |> Enum.map(fn {_session_id, game} -> game end)
@@ -137,6 +142,7 @@ defmodule Blog.Wordle.GameStore do
   @doc """
   Gets all active game sessions as a map
   """
+  @spec all_games_map() :: %{optional(String.t()) => map()}
   def all_games_map do
     :ets.tab2list(@games_table)
     |> Enum.filter(fn {_session_id, game} -> valid_game?(game) end)
@@ -146,6 +152,7 @@ defmodule Blog.Wordle.GameStore do
   @doc """
   Removes stale games older than the given time period
   """
+  @spec cleanup_stale_games(number()) :: :ok
   def cleanup_stale_games(hours \\ 24) do
     cutoff = DateTime.add(DateTime.utc_now(), -hours * 60 * 60, :second) |> DateTime.to_iso8601()
 
@@ -166,6 +173,7 @@ defmodule Blog.Wordle.GameStore do
   @doc """
   Cleans up problematic game entries (e.g., games with missing fields)
   """
+  @spec cleanup_problematic_games() :: :ok
   def cleanup_problematic_games do
     deleted_count =
       :ets.tab2list(@games_table)
@@ -184,6 +192,7 @@ defmodule Blog.Wordle.GameStore do
   @doc """
   Cleans up duplicate sessions for the same player, keeping only the most recent one
   """
+  @spec cleanup_duplicate_player_sessions() :: :ok
   def cleanup_duplicate_player_sessions do
     # Group games by player_id
     games_by_player =
@@ -225,6 +234,7 @@ defmodule Blog.Wordle.GameStore do
   @doc """
   Validates that a game has all required fields
   """
+  @spec valid_game?(term()) :: boolean()
   def valid_game?(game) do
     # Check that all the important fields exist and have valid values
     is_map(game) &&

--- a/lib/blog/wordle/guess_checker.ex
+++ b/lib/blog/wordle/guess_checker.ex
@@ -1,8 +1,12 @@
 defmodule Blog.Wordle.GuessChecker do
+  @typedoc "Result for a single letter position in a guess."
+  @type letter_result :: :correct | :present | :absent
+
   @doc """
   Checks a guess against the target word in normal mode.
   Returns a list of :correct, :present, or :absent atoms.
   """
+  @spec check_guess(String.t(), String.t()) :: [letter_result()]
   def check_guess(guess, target) do
     do_check_guess(guess, target)
   end
@@ -12,6 +16,8 @@ defmodule Blog.Wordle.GuessChecker do
   Returns {:error, message} if the guess doesn't use required letters,
   or {:ok, results} with the list of :correct, :present, or :absent atoms.
   """
+  @spec check_guess(String.t(), String.t(), [%{required(:word) => String.t(), required(:result) => [letter_result()]}]) ::
+          {:ok, [letter_result()]} | {:error, String.t()}
   def check_guess(guess, target, previous_results) when is_list(previous_results) do
     required_letters = get_required_letters(previous_results)
 

--- a/lib/blog/wordle/word_store.ex
+++ b/lib/blog/wordle/word_store.ex
@@ -7,6 +7,7 @@ defmodule Blog.Wordle.WordStore do
   @potential_words_table :wordle_potential_words
   @valid_guesses_table :wordle_valid_guesses
 
+  @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts \\ []) do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
@@ -31,6 +32,7 @@ defmodule Blog.Wordle.WordStore do
     {:ok, %{}}
   end
 
+  @spec valid_guess?(term()) :: boolean()
   def valid_guess?(word) do
     case :ets.lookup(@valid_guesses_table, word) do
       [{^word, true}] -> true
@@ -38,6 +40,7 @@ defmodule Blog.Wordle.WordStore do
     end
   end
 
+  @spec potential_word?(term()) :: boolean()
   def potential_word?(word) do
     case :ets.lookup(@potential_words_table, word) do
       [{^word, true}] -> true
@@ -45,6 +48,7 @@ defmodule Blog.Wordle.WordStore do
     end
   end
 
+  @spec get_random_word() :: String.t()
   def get_random_word do
     # Get a random word from the potential words table
     word =


### PR DESCRIPTION
Part of the gradual-typing pass (see `PROCESS.md`), branched from the merged Assay baseline. Adds `@type`/`@spec` to the `wordle` subsystem; each spec written from the implementation and independently reviewed.

**Verified:** `mix compile --warnings-as-errors` clean, `mix assay` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)