### PR TITLE
Phase 3 (types): standalone context modules + latent 500 fix

### DIFF
--- a/lib/blog/cursor_points.ex
+++ b/lib/blog/cursor_points.ex
@@ -16,16 +16,25 @@ defmodule Blog.CursorPoints do
   # 60 minutes in milliseconds
   @clear_interval 60 * 60 * 1000
 
+  @typedoc """
+  A cursor drawing point. Stored as a map; the store reads the `:user_id`
+  and `:timestamp` (a `DateTime`) keys.
+  """
+  @type point :: map()
+
   # Client API
 
+  @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts) do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
+  @spec add_point(point()) :: :ok
   def add_point(point) do
     GenServer.cast(__MODULE__, {:add_point, point})
   end
 
+  @spec get_points() :: [point()]
   def get_points do
     case :ets.info(@table_name) do
       :undefined -> []
@@ -33,6 +42,7 @@ defmodule Blog.CursorPoints do
     end
   end
 
+  @spec clear_points() :: :ok
   def clear_points do
     GenServer.cast(__MODULE__, :clear_points)
   end

--- a/lib/blog/geo_map.ex
+++ b/lib/blog/geo_map.ex
@@ -17,6 +17,7 @@ defmodule Blog.GeoMap do
       [%TagIn{}, ...]
 
   """
+  @spec list_tag_ins() :: [struct()]
   def list_tag_ins do
     Repo.all(TagIn)
   end
@@ -35,6 +36,7 @@ defmodule Blog.GeoMap do
       ** (Ecto.NoResultsError)
 
   """
+  @spec get_tag_in!(term()) :: struct()
   def get_tag_in!(id), do: Repo.get!(TagIn, id)
 
   @doc """
@@ -49,6 +51,7 @@ defmodule Blog.GeoMap do
       {:error, %Ecto.Changeset{}}
 
   """
+  @spec create_tag_in(map()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def create_tag_in(attrs \\ %{}) do
     %TagIn{}
     |> TagIn.changeset(attrs)
@@ -67,6 +70,7 @@ defmodule Blog.GeoMap do
       {:error, %Ecto.Changeset{}}
 
   """
+  @spec update_tag_in(struct(), map()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def update_tag_in(%TagIn{} = tag_in, attrs) do # Changed from :tag_in to :TagIn
     tag_in
     |> TagIn.changeset(attrs)
@@ -85,6 +89,7 @@ defmodule Blog.GeoMap do
       {:error, %Ecto.Changeset{}}
 
   """
+  @spec delete_tag_in(struct()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
   def delete_tag_in(%TagIn{} = tag_in) do # Changed from :tag_in to :TagIn
     Repo.delete(tag_in)
   end
@@ -98,6 +103,7 @@ defmodule Blog.GeoMap do
       %Ecto.Changeset{data: %TagIn{}} # Changed from :tag_in to :TagIn
 
   """
+  @spec change_tag_in(struct(), map()) :: Ecto.Changeset.t()
   def change_tag_in(%TagIn{} = tag_in, attrs \\ %{}) do # Changed from :tag_in to :TagIn
     TagIn.changeset(tag_in, attrs)
   end

--- a/lib/blog/hose_monitor.ex
+++ b/lib/blog/hose_monitor.ex
@@ -7,6 +7,13 @@ defmodule Blog.HoseMonitor do
 
   @table :hose_monitor_status
 
+  @typedoc "Name of a firehose client, e.g. :jetstream."
+  @type hose_name :: atom()
+
+  @typedoc "Connection state of a hose."
+  @type hose_status :: :up | :down
+
+  @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts) do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
@@ -25,16 +32,19 @@ defmodule Blog.HoseMonitor do
   end
 
   @doc "Report a hose as connected."
+  @spec report_up(hose_name()) :: true
   def report_up(hose_name) do
     :ets.insert(@table, {hose_name, :up})
   end
 
   @doc "Report a hose as disconnected."
+  @spec report_down(hose_name()) :: true
   def report_down(hose_name) do
     :ets.insert(@table, {hose_name, :down})
   end
 
   @doc "Returns a map of hose statuses, e.g. %{jetstream: :up, turbostream: :down, ...}"
+  @spec status() :: %{optional(hose_name()) => hose_status()}
   def status do
     case :ets.whereis(@table) do
       :undefined -> %{bluesky_hose: :down, jetstream: :down, turbostream: :down}
@@ -43,11 +53,13 @@ defmodule Blog.HoseMonitor do
   end
 
   @doc "Returns true if any hose is down."
+  @spec any_down?() :: boolean()
   def any_down? do
     status() |> Map.values() |> Enum.any?(&(&1 == :down))
   end
 
   @doc "Returns list of down hose names."
+  @spec down_hoses() :: [hose_name()]
   def down_hoses do
     status()
     |> Enum.filter(fn {_k, v} -> v == :down end)

--- a/lib/blog/live_draft.ex
+++ b/lib/blog/live_draft.ex
@@ -9,6 +9,7 @@ defmodule Blog.LiveDraft do
   @staleness_seconds 120
   @posts_dir (:code.priv_dir(:blog) |> to_string()) <> "/static/posts/"
 
+  @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts) do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
@@ -39,6 +40,7 @@ defmodule Blog.LiveDraft do
   end
 
   @doc "Store a live draft, persist to disk, and broadcast via PubSub"
+  @spec update(String.t(), String.t()) :: {:ok, String.t()}
   def update(slug, content) do
     rendered_html = render_markdown(content)
     now = DateTime.utc_now()
@@ -57,6 +59,7 @@ defmodule Blog.LiveDraft do
   end
 
   @doc "Apply a line-level diff to the stored content for a slug"
+  @spec apply_diff(String.t(), [list()]) :: {:ok, String.t()}
   def apply_diff(slug, ops) do
     current_content =
       case :ets.lookup(@table, slug) do
@@ -72,6 +75,7 @@ defmodule Blog.LiveDraft do
   end
 
   @doc "Get the current live draft for a slug, or :stale/:none"
+  @spec get(String.t()) :: {:ok, String.t(), DateTime.t()} | :stale | :none
   def get(slug) do
     case :ets.lookup(@table, slug) do
       [{^slug, _content, rendered_html, updated_at}] ->
@@ -87,6 +91,7 @@ defmodule Blog.LiveDraft do
   end
 
   @doc "Clear a live draft"
+  @spec clear(String.t()) :: :ok
   def clear(slug) do
     :ets.delete(@table, slug)
 

--- a/lib/blog/python_runner.ex
+++ b/lib/blog/python_runner.ex
@@ -1,6 +1,7 @@
 defmodule Blog.PythonRunner do
   require Logger
 
+  @spec init_python() :: :ok | {:error, String.t()}
   def init_python do
     try do
       config_str = """
@@ -32,6 +33,7 @@ defmodule Blog.PythonRunner do
     end
   end
 
+  @spec run_python_code(String.t()) :: {:ok, term()} | {:error, String.t()}
   def run_python_code(code) when is_binary(code) do
     case init_python() do
       :ok ->

--- a/lib/blog/receipt_message.ex
+++ b/lib/blog/receipt_message.ex
@@ -2,6 +2,20 @@ defmodule Blog.ReceiptMessage do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{
+          id: integer() | nil,
+          content: String.t() | nil,
+          sender_name: String.t() | nil,
+          sender_ip: String.t() | nil,
+          image_url: String.t() | nil,
+          image_data: binary() | nil,
+          image_content_type: String.t() | nil,
+          printed_at: DateTime.t() | nil,
+          status: String.t() | nil,
+          inserted_at: NaiveDateTime.t() | nil,
+          updated_at: NaiveDateTime.t() | nil
+        }
+
   schema "receipt_messages" do
     field :content, :string
     field :sender_name, :string
@@ -16,6 +30,7 @@ defmodule Blog.ReceiptMessage do
   end
 
   @doc false
+  @spec changeset(t() | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   def changeset(receipt_message, attrs) do
     receipt_message
     |> cast(attrs, [:content, :sender_name, :sender_ip, :image_url, :image_data, :image_content_type, :status, :printed_at])

--- a/lib/blog/receipt_messages.ex
+++ b/lib/blog/receipt_messages.ex
@@ -10,6 +10,7 @@ defmodule Blog.ReceiptMessages do
   @doc """
   Returns the list of receipt_messages.
   """
+  @spec list_receipt_messages() :: [Blog.ReceiptMessage.t()]
   def list_receipt_messages do
     Repo.all(ReceiptMessage)
   end
@@ -17,6 +18,7 @@ defmodule Blog.ReceiptMessages do
   @doc """
   Returns the list of pending receipt_messages.
   """
+  @spec list_recent_messages(non_neg_integer()) :: [Blog.ReceiptMessage.t()]
   def list_recent_messages(limit \\ 10) do
     ReceiptMessage
     |> order_by([m], desc: m.inserted_at)
@@ -24,6 +26,7 @@ defmodule Blog.ReceiptMessages do
     |> Repo.all()
   end
 
+  @spec list_pending_messages() :: [Blog.ReceiptMessage.t()]
   def list_pending_messages do
     ReceiptMessage
     |> where([m], m.status == "pending")
@@ -34,11 +37,20 @@ defmodule Blog.ReceiptMessages do
   @doc """
   Gets a single receipt_message.
   """
+  @spec get_receipt_message!(integer() | String.t()) :: Blog.ReceiptMessage.t()
   def get_receipt_message!(id), do: Repo.get!(ReceiptMessage, id)
+
+  @doc """
+  Gets a single receipt_message, returning nil if it does not exist.
+  """
+  @spec get_receipt_message(integer() | String.t()) :: Blog.ReceiptMessage.t() | nil
+  def get_receipt_message(id), do: Repo.get(ReceiptMessage, id)
 
   @doc """
   Creates a receipt_message.
   """
+  @spec create_receipt_message(map()) ::
+          {:ok, Blog.ReceiptMessage.t()} | {:error, Ecto.Changeset.t()}
   def create_receipt_message(attrs \\ %{}) do
     %ReceiptMessage{}
     |> ReceiptMessage.changeset(attrs)
@@ -49,6 +61,8 @@ defmodule Blog.ReceiptMessages do
   @doc """
   Updates a receipt_message.
   """
+  @spec update_receipt_message(Blog.ReceiptMessage.t(), map()) ::
+          {:ok, Blog.ReceiptMessage.t()} | {:error, Ecto.Changeset.t()}
   def update_receipt_message(%ReceiptMessage{} = receipt_message, attrs) do
     receipt_message
     |> ReceiptMessage.changeset(attrs)
@@ -58,6 +72,8 @@ defmodule Blog.ReceiptMessages do
   @doc """
   Marks a message as printed.
   """
+  @spec mark_as_printed(Blog.ReceiptMessage.t()) ::
+          {:ok, Blog.ReceiptMessage.t()} | {:error, Ecto.Changeset.t()}
   def mark_as_printed(%ReceiptMessage{} = receipt_message) do
     update_receipt_message(receipt_message, %{
       status: "printed",
@@ -68,6 +84,8 @@ defmodule Blog.ReceiptMessages do
   @doc """
   Marks a message as failed.
   """
+  @spec mark_as_failed(Blog.ReceiptMessage.t()) ::
+          {:ok, Blog.ReceiptMessage.t()} | {:error, Ecto.Changeset.t()}
   def mark_as_failed(%ReceiptMessage{} = receipt_message) do
     update_receipt_message(receipt_message, %{status: "failed"})
   end
@@ -75,6 +93,8 @@ defmodule Blog.ReceiptMessages do
   @doc """
   Deletes a receipt_message.
   """
+  @spec delete_receipt_message(Blog.ReceiptMessage.t()) ::
+          {:ok, Blog.ReceiptMessage.t()} | {:error, Ecto.Changeset.t()}
   def delete_receipt_message(%ReceiptMessage{} = receipt_message) do
     Repo.delete(receipt_message)
   end
@@ -82,6 +102,7 @@ defmodule Blog.ReceiptMessages do
   @doc """
   Returns an `%Ecto.Changeset{}` for tracking receipt_message changes.
   """
+  @spec change_receipt_message(Blog.ReceiptMessage.t(), map()) :: Ecto.Changeset.t()
   def change_receipt_message(%ReceiptMessage{} = receipt_message, attrs \\ %{}) do
     ReceiptMessage.changeset(receipt_message, attrs)
   end

--- a/lib/blog/reddit_bookmark_processor.ex
+++ b/lib/blog/reddit_bookmark_processor.ex
@@ -3,6 +3,7 @@ defmodule Blog.RedditBookmarkProcessor do
   alias Blog.Bookmarks.{Store, Bookmark}
   require Logger
 
+  @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts) do
     GenServer.start_link(__MODULE__, %{count: 0}, name: __MODULE__)
   end

--- a/lib/blog/release.ex
+++ b/lib/blog/release.ex
@@ -5,6 +5,7 @@ defmodule Blog.Release do
   """
   @app :blog
 
+  @spec migrate() :: [{:ok, term(), term()}]
   def migrate do
     load_app()
     
@@ -16,6 +17,7 @@ defmodule Blog.Release do
     end
   end
 
+  @spec seed_sky_profiles() :: {:ok, term(), term()}
   def seed_sky_profiles do
     load_app()
     Application.ensure_all_started(:ssl)
@@ -62,6 +64,7 @@ defmodule Blog.Release do
       end)
   end
 
+  @spec rollback(Ecto.Repo.t(), integer()) :: {:ok, term(), term()}
   def rollback(repo, version) do
     load_app()
     {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :down, to: version))

--- a/lib/blog/skeet_store.ex
+++ b/lib/blog/skeet_store.ex
@@ -10,6 +10,7 @@ defmodule Blog.SkeetStore do
   Initialize the ETS table for storing skeets.
   Will safely handle cases where the table already exists.
   """
+  @spec init() :: :ok
   def init do
     case :ets.info(@table_name) do
       :undefined ->
@@ -34,6 +35,7 @@ defmodule Blog.SkeetStore do
   Ensures only the most recent @max_skeets skeets are kept.
   Safely handles cases where the table doesn't exist yet.
   """
+  @spec add_skeet(term()) :: :ok | :error
   def add_skeet(skeet) do
     # Ensure the table exists
     init()
@@ -55,6 +57,7 @@ defmodule Blog.SkeetStore do
   Get the most recent skeets, sorted by timestamp (newest first).
   Safely handles cases where the table doesn't exist yet.
   """
+  @spec get_recent_skeets(non_neg_integer()) :: [map()]
   def get_recent_skeets(limit \\ @max_skeets) do
     # Ensure the table exists
     init()

--- a/lib/blog/storage.ex
+++ b/lib/blog/storage.ex
@@ -3,15 +3,18 @@ defmodule Blog.Storage do
   S3-compatible object storage via Hetzner Object Storage.
   """
 
+  @spec bucket() :: String.t()
   def bucket do
     Application.get_env(:blog, :s3_bucket, "bobbby-media")
   end
 
+  @spec create_bucket() :: {:ok, term()} | {:error, term()}
   def create_bucket do
     ExAws.S3.put_bucket(bucket(), "fsn1")
     |> ExAws.request()
   end
 
+  @spec upload(String.t(), binary(), keyword()) :: {:ok, term()} | {:error, term()}
   def upload(key, data, opts \\ []) do
     content_type = Keyword.get(opts, :content_type, "application/octet-stream")
     acl = Keyword.get(opts, :acl, :public_read)
@@ -23,15 +26,18 @@ defmodule Blog.Storage do
     |> ExAws.request()
   end
 
+  @spec delete(String.t()) :: {:ok, term()} | {:error, term()}
   def delete(key) do
     ExAws.S3.delete_object(bucket(), key)
     |> ExAws.request()
   end
 
+  @spec url(String.t()) :: String.t()
   def url(key) do
     "https://#{bucket()}.fsn1.your-objectstorage.com/#{key}"
   end
 
+  @spec list(String.t()) :: {:ok, term()} | {:error, term()}
   def list(prefix \\ "") do
     ExAws.S3.list_objects(bucket(), prefix: prefix)
     |> ExAws.request()

--- a/lib/blog/tag_in.ex
+++ b/lib/blog/tag_in.ex
@@ -2,6 +2,17 @@ defmodule Blog.TagIn do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{
+          id: Ecto.UUID.t() | nil,
+          user_name: String.t() | nil,
+          spotify_link: String.t() | nil,
+          note: String.t() | nil,
+          latitude: float() | nil,
+          longitude: float() | nil,
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "tag_ins" do
@@ -15,6 +26,7 @@ defmodule Blog.TagIn do
   end
 
   @doc false
+  @spec changeset(t() | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   def changeset(tag_in, attrs) do
     tag_in
     |> cast(attrs, [:user_name, :spotify_link, :note, :latitude, :longitude])

--- a/lib/blog/wordle_words.ex
+++ b/lib/blog/wordle_words.ex
@@ -1,4 +1,10 @@
 defmodule Blog.WordleWords do
+  @moduledoc """
+  Static word lists for the Wordle mini-app: the full set of valid five-letter
+  guesses and the smaller set of potential answer words.
+  """
+
+  @spec valid_guesses() :: [String.t()]
   def valid_guesses do
     ~W(
     aahed
@@ -14859,6 +14865,7 @@ defmodule Blog.WordleWords do
     )
   end
 
+  @spec potential_words() :: [String.t()]
   def potential_words do
     ~W(
     about

--- a/lib/blog_web/controllers/receipt_api_controller.ex
+++ b/lib/blog_web/controllers/receipt_api_controller.ex
@@ -12,7 +12,7 @@ defmodule BlogWeb.ReceiptApiController do
   end
   
   def mark_printed(conn, %{"id" => id}) do
-    case ReceiptMessages.get_receipt_message!(id) do
+    case ReceiptMessages.get_receipt_message(id) do
       nil ->
         conn
         |> put_status(:not_found)
@@ -35,7 +35,7 @@ defmodule BlogWeb.ReceiptApiController do
   end
   
   def mark_failed(conn, %{"id" => id}) do
-    case ReceiptMessages.get_receipt_message!(id) do
+    case ReceiptMessages.get_receipt_message(id) do
       nil ->
         conn
         |> put_status(:not_found)


### PR DESCRIPTION
Part of the gradual-typing pass (see `PROCESS.md`). Covers the top-level `lib/blog/*.ex` context modules not part of any subsystem — one PR since they're individually small. 50 specs + 5 types across 13 modules, each independently reviewed.

**Fixes a latent bug the typing exposed:** `ReceiptApiController` called `get_receipt_message!/1` (raises on not-found) but matched a `nil ->` 404 branch, so a missing id returned 500 instead of 404. Added a non-raising `get_receipt_message/1` and repointed the controller. Also corrected `receipt_message`'s `timestamps()` type to `NaiveDateTime`.

**Verified:** `mix compile --warnings-as-errors` clean, `mix assay` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)