### PR TITLE
Phase 5: remove dead Content.list_posts/0 + parsing helpers

### DIFF
--- a/lib/blog/content.ex
+++ b/lib/blog/content.ex
@@ -1,60 +1,12 @@
 defmodule Blog.Content do
   @moduledoc """
-  Handles parsing and categorizing posts from markdown files.
+  Categorizes posts into tech / non-tech buckets by tag.
+
+  Post loading/parsing lives in `Blog.Content.Post`; this module only sorts an
+  existing list of posts into categories.
   """
 
   @tech_tags ~w(programming tech software coding elixir javascript phoenix blog)
-  @posts_dir "priv/static/posts/"
-
-  @typedoc "A post summary parsed from a markdown file (tags as raw strings)."
-  @type post_summary :: %{
-          title: String.t(),
-          tags: [String.t()],
-          content: String.t(),
-          written_on: Date.t(),
-          slug: String.t()
-        }
-
-  @spec list_posts() :: [post_summary()]
-  def list_posts do
-    File.ls!(@posts_dir)
-    |> Enum.map(&parse_post/1)
-    |> Enum.sort_by(& &1.written_on, {:desc, Date})
-  end
-
-  defp parse_post(filename) do
-    content = File.read!(@posts_dir <> filename)
-
-    %{
-      title: parse_title(content),
-      tags: parse_tags(content),
-      content: content,
-      written_on: parse_date_from_filename(filename),
-      slug: Path.basename(filename, ".md")
-    }
-  end
-
-  defp parse_date_from_filename(filename) do
-    case Regex.run(~r/(\d{4}-\d{2}-\d{2})/, filename) do
-      [_, date] ->
-        {:ok, date} = Date.from_iso8601(date)
-        date
-
-      nil ->
-        {:ok, stat} = File.stat(@posts_dir <> filename)
-        NaiveDateTime.to_date(stat.mtime)
-    end
-  end
-
-  defp parse_title(content) do
-    [_, title] = Regex.run(~r/title: (.+)/, content)
-    title
-  end
-
-  defp parse_tags(content) do
-    [_, tags] = Regex.run(~r/tags: (.+)/, content)
-    String.split(tags, ",") |> Enum.map(&String.trim/1)
-  end
 
   @spec categorize_posts([Blog.Content.Post.t()]) :: %{
           tech: [Blog.Content.Post.t()],

--- a/test/blog/content_test.exs
+++ b/test/blog/content_test.exs
@@ -3,45 +3,6 @@ defmodule Blog.ContentTest do
   alias Blog.Content
   alias Blog.Content.Tag
 
-  import ExUnit.CaptureIO
-
-  # Blog.Content.list_posts/0 is legacy: it parses a "title:" front-matter line
-  # that current posts no longer have (parse_title/1 crashes on them), and it is
-  # unused in the app — only Content.categorize_posts/1 is called in production
-  # (post_live/index.ex), with posts from Blog.Content.Post.all/0. Skipped here
-  # and flagged for removal in Phase 5 rather than reviving broken dead code.
-  describe "list_posts/0" do
-    @describetag :skip
-    test "returns list of posts" do
-      posts = Content.list_posts()
-      assert is_list(posts)
-
-      for post <- posts do
-        assert Map.has_key?(post, :title)
-        assert Map.has_key?(post, :tags)
-        assert Map.has_key?(post, :content)
-        assert Map.has_key?(post, :written_on)
-        assert Map.has_key?(post, :slug)
-
-        assert is_binary(post.title)
-        assert is_list(post.tags)
-        assert is_binary(post.content)
-        assert %Date{} = post.written_on
-        assert is_binary(post.slug)
-      end
-    end
-
-    test "posts are sorted by written_on in descending order" do
-      posts = Content.list_posts()
-
-      if length(posts) > 1 do
-        dates = Enum.map(posts, & &1.written_on)
-        sorted_dates = Enum.sort(dates, {:desc, Date})
-        assert dates == sorted_dates
-      end
-    end
-  end
-
   describe "categorize_posts/1" do
     setup do
       # Create test posts with different tag types


### PR DESCRIPTION
First Phase 5 cleanup, using a dead-code finding from Phases 3–4.

`Blog.Content.list_posts/0` (and its private `parse_post`/`parse_title`/`parse_tags`/`parse_date_from_filename` helpers) parsed a `title:` front-matter line current posts don't have — `parse_title/1` crashed on them — and had **zero callers**. Post loading is `Blog.Content.Post.all/0`; only `categorize_posts/1` is used in prod (`post_live/index.ex`).

Removed the dead functions, the now-unused `@posts_dir` and `post_summary` type, and the skipped `list_posts` tests. `-91 lines`.

**Verified:** `mix compile --warnings-as-errors` clean, `mix assay` 0 errors, `mix test` → 570/0/1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)